### PR TITLE
Add mixin for generating spacing classes

### DIFF
--- a/src/indigo/less/indigo.less
+++ b/src/indigo/less/indigo.less
@@ -186,3 +186,4 @@ body {
 @import 'kbc-user';
 
 @import "components/tabs";
+@import "utilities/spacing";

--- a/src/indigo/less/utilities/spacing.less
+++ b/src/indigo/less/utilities/spacing.less
@@ -1,0 +1,56 @@
+
+.make-spacing-classes(@n, @i: 1) when (@i =< @n) {
+  @base: .5rem;
+  // margins
+  .m-@{n} {
+    margin: @n * @base;
+  }
+  .mt-@{n} {
+    margin-top: @n * @base;
+  }
+  .mr-@{n} {
+    margin-right: @n * @base;
+  }
+  .mb-@{n} {
+    margin-bottom: @n * @base;
+  }
+  .ml-@{n} {
+    margin-left: @n * @base;
+  }
+  .mx-@{n} {
+    margin-left: @n * @base;
+    margin-right: @n * @base;
+  }
+  .my-@{n} {
+    margin-top: @n * @base;
+    margin-bottom: @n * @base;
+  }
+  // paddings
+  .p-@{n} {
+    padding: @n * @base;
+  }
+  .pt-@{n} {
+    padding-top: @n * @base;
+  }
+  .pr-@{n} {
+    padding-right: @n * @base;
+  }
+  .pb-@{n} {
+    padding-bottom: @n * @base;
+  }
+  .pl-@{n} {
+    padding-left: @n * @base;
+  }
+  .px-@{n} {
+    padding-left: @n * @base;
+    padding-right: @n * @base;
+  }
+  .py-@{n} {
+    padding-top: @n * @base;
+    padding-bottom: @n * @base;
+  }
+
+  .make-spacing-classes(@n - 1);
+}
+
+.make-spacing-classes(6);


### PR DESCRIPTION
Fixes #106 

There are 6 loops, multiplying base (.5rem) with loop number. 

- Loop 1: `.5rem`
- Loop 2: `1rem`
- ...
- Loop 6: `3rem`

Sample, for loop 1:

```css
.m-1 {
  margin: 0.5rem;
}
.mt-1 {
  margin-top: 0.5rem;
}
.mr-1 {
  margin-right: 0.5rem;
}
.mb-1 {
  margin-bottom: 0.5rem;
}
.ml-1 {
  margin-left: 0.5rem;
}
.mx-1 {
  margin-left: 0.5rem;
  margin-right: 0.5rem;
}
.my-1 {
  margin-top: 0.5rem;
  margin-bottom: 0.5rem;
}
.p-1 {
  padding: 0.5rem;
}
.pt-1 {
  padding-top: 0.5rem;
}
.pr-1 {
  padding-right: 0.5rem;
}
.pb-1 {
  padding-bottom: 0.5rem;
}
.pl-1 {
  padding-left: 0.5rem;
}
.px-1 {
  padding-left: 0.5rem;
  padding-right: 0.5rem;
}
.py-1 {
  padding-top: 0.5rem;
  padding-bottom: 0.5rem;
}
```

For now I didn't add classes for reseting.