### PR TITLE
Fix react create class warning

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["env", "react"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "@storybook/addon-options": "^3.4.1",
     "@storybook/react": "^3.2.17",
     "babel-cli": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
     "fixed-data-table": "^0.6.4",
     "grunt": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
@@ -69,12 +69,5 @@
   "homepage": "https://github.com/keboola/indigo-ui",
   "files": [
     "lib"
-  ],
-  "babel": {
-    "presets": [
-      "es2015",
-      "react",
-      "stage-0"
-    ]
-  }
+  ]
 }

--- a/src/indigo/components/AlertBlock.jsx
+++ b/src/indigo/components/AlertBlock.jsx
@@ -2,13 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from 'react-bootstrap';
 
-export default React.createClass({
-  propTypes: {
-    title: PropTypes.string.isRequired,
-    type: PropTypes.oneOf(['warning', 'danger']).isRequired,
-    children: PropTypes.any.isRequired
-  },
-
+class AlertBlock extends React.Component {
   render() {
     const { type, title, children } = this.props;
     return (
@@ -20,4 +14,12 @@ export default React.createClass({
       </Alert>
     );
   }
-});
+}
+
+AlertBlock.propTypes = {
+  title: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['warning', 'danger']).isRequired,
+  children: PropTypes.any.isRequired
+};
+
+export default AlertBlock;

--- a/src/indigo/components/Check.jsx
+++ b/src/indigo/components/Check.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Check = React.createClass({
-  propTypes: {
-    isChecked: PropTypes.bool.isRequired
-  },
-
+class Check extends React.Component {
   render() {
     return (
       <i className={this.props.isChecked ? 'fa fa-fw fa-check' : 'fa fa-fw fa-times'}/>
     );
   }
-});
+}
+
+Check.propTypes = {
+  isChecked: PropTypes.bool.isRequired
+};
 
 export default Check;

--- a/src/indigo/components/Loader.jsx
+++ b/src/indigo/components/Loader.jsx
@@ -2,15 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export default React.createClass({
-  propTypes: {
-    className: PropTypes.string
-  },
-
+class Loader extends React.Component {
   render() {
     return (
       <span className={classNames('fa fa-spin fa-spinner', this.props.className)}/>
     );
   }
+}
 
-});
+Loader.propTypes = {
+  className: PropTypes.string
+};
+
+export default Loader;

--- a/src/indigo/components/NewLineToBr.jsx
+++ b/src/indigo/components/NewLineToBr.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default React.createClass({
-  propTypes: {
-    text: PropTypes.string.isRequired
-  },
-
+class NewLineToBr extends React.Component {
   render() {
     const lines = this.props.text.split('\n');
     let result = [];
@@ -20,5 +16,11 @@ export default React.createClass({
     return (
       <span>{result}</span>
     );
-  },
-});
+  }
+}
+
+NewLineToBr.propTypes = {
+  text: PropTypes.string.isRequired
+};
+
+export default NewLineToBr;

--- a/src/indigo/components/PanelWithDetails.jsx
+++ b/src/indigo/components/PanelWithDetails.jsx
@@ -2,30 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Panel} from 'react-bootstrap';
 
-export default React.createClass({
-
-  propTypes: {
-    defaultExpanded: PropTypes.bool,
-    labelCollapse: PropTypes.string,
-    labelOpen: PropTypes.string,
-    children: PropTypes.any.isRequired,
-    placement: PropTypes.oneOf(['top', 'bottom'])
-  },
-
-  getDefaultProps() {
-    return ({
-      defaultExpanded: false,
-      labelCollapse: 'Hide details',
-      labelOpen: 'Show details',
-      placement: 'top'
-    });
-  },
-
-  getInitialState() {
-    return ({
-      panelHeaderTitle: this.props.defaultExpanded ? this.props.labelCollapse : this.props.labelOpen
-    });
-  },
+class PanelWithDetails extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      panelHeaderTitle: props.defaultExpanded ? props.labelCollapse : props.labelOpen
+    };
+  }
 
   render() {
     return (
@@ -41,4 +24,21 @@ export default React.createClass({
       </Panel>
     );
   }
-});
+}
+
+PanelWithDetails.propTypes = {
+  defaultExpanded: PropTypes.bool,
+  labelCollapse: PropTypes.string,
+  labelOpen: PropTypes.string,
+  children: PropTypes.any.isRequired,
+  placement: PropTypes.oneOf(['top', 'bottom'])
+};
+
+PanelWithDetails.defaultProps = {
+  defaultExpanded: false,
+  labelCollapse: 'Hide details',
+  labelOpen: 'Show details',
+  placement: 'top'
+};
+
+export default PanelWithDetails;

--- a/src/indigo/components/Protected.jsx
+++ b/src/indigo/components/Protected.jsx
@@ -1,20 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default React.createClass({
-  propTypes: {
-    children: PropTypes.any
-  },
-
-  getInitialState() {
-    return {
+class Protected extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       isProtected: true
     };
-  },
+  }
 
   render() {
     return this.state.isProtected ? this.renderProtected() : this.renderRevealed();
-  },
+  }
 
   renderProtected() {
     return (
@@ -22,17 +19,23 @@ export default React.createClass({
             title="Protected content, click to reveal"
             onClick={this.show} />
     );
-  },
+  }
 
   renderRevealed() {
     return (
       <span>{this.props.children}</span>
     );
-  },
+  }
 
   show() {
     this.setState({
       isProtected: false
     });
   }
-});
+}
+
+Protected.propTypes = {
+  children: PropTypes.any
+};
+
+export default Protected;

--- a/src/indigo/components/RefreshIcon.jsx
+++ b/src/indigo/components/RefreshIcon.jsx
@@ -3,18 +3,7 @@ import PropTypes from 'prop-types';
 
 import Loader from './Loader';
 
-const RefreshIcon = React.createClass({
-  propTypes: {
-    isLoading: PropTypes.bool.isRequired,
-    title: PropTypes.string
-  },
-
-  getDefaultProps() {
-    return {
-      title: 'Refresh'
-    };
-  },
-
+class RefreshIcon extends React.Component {
   render() {
     const { isLoading, title, ...remaining } = this.props;
     return (
@@ -24,7 +13,16 @@ const RefreshIcon = React.createClass({
           : <span {...remaining} className="kbc-refresh kbc-icon-cw" />}
       </span>
     );
-  },
-});
+  }
+}
+
+RefreshIcon.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  title: PropTypes.string
+};
+
+RefreshIcon.defaultProps = {
+  title: 'Refresh'
+};
 
 export default RefreshIcon;

--- a/src/indigo/components/Tree.jsx
+++ b/src/indigo/components/Tree.jsx
@@ -3,12 +3,7 @@ import PropTypes from 'prop-types';
 
 import TreeNode from './tree/TreeNode';
 
-export default React.createClass({
-  propTypes: {
-    data: PropTypes.object.isRequired,
-    onClick: PropTypes.func
-  },
-
+class Tree extends React.Component {
   render() {
     return (
       <div className="kb-tree" onClick={this.props.onClick}>
@@ -16,5 +11,11 @@ export default React.createClass({
       </div>
     );
   }
+}
 
-});
+Tree.propTypes = {
+  data: PropTypes.object.isRequired,
+  onClick: PropTypes.func
+};
+
+export default Tree;

--- a/src/indigo/components/tree/TreeNode.jsx
+++ b/src/indigo/components/tree/TreeNode.jsx
@@ -4,20 +4,16 @@ import Immutable from 'immutable';
 
 import Protected from '../Protected';
 
-const TreeNode = React.createClass({
-  propTypes: {
-    data: PropTypes.object.isRequired
-  },
+const concealedKeys = ["password"];
 
-  concealedKeys: ["password"],
-
+class TreeNode extends React.Component {
   render() {
     return (
-        <ul>
-          {this.props.data.map(this.renderRow, this).valueSeq()}
-        </ul>
+      <ul>
+        {this.props.data.map(this.renderRow, this).valueSeq()}
+      </ul>
     );
-  },
+  }
 
   renderRow(value, key) {
     return (
@@ -25,7 +21,7 @@ const TreeNode = React.createClass({
         {Immutable.Iterable.isIterable(value) ? this.renderNode(value, key) : this.renderLeaf(value, key)}
       </li>
     );
-  },
+  }
 
   renderNode(value, key) {
     return (
@@ -34,17 +30,17 @@ const TreeNode = React.createClass({
         <TreeNode data={value}/>
       </span>
     );
-  },
+  }
 
   renderValue(value, key) {
-    if (this.concealedKeys.indexOf(key) >= 0) {
+    if (concealedKeys.indexOf(key) >= 0) {
       return (
         <Protected>{String(value)}</Protected>
       );
     } else {
       return String(value);
     }
-  },
+  }
 
   renderLeaf(value, key) {
     return (
@@ -53,6 +49,10 @@ const TreeNode = React.createClass({
       </span>
     );
   }
-});
+}
+
+TreeNode.propTypes = {
+  data: PropTypes.object.isRequired
+};
 
 export default TreeNode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,17 +1141,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    lodash "^4.17.4"
-
-babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
+babel-plugin-transform-es2015-classes@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -1165,33 +1155,33 @@ babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-cla
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.22.0, babel-plugin-transform-es2015-computed-properties@^6.24.1:
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.22.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
+babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-duplicate-keys@^6.22.0, babel-plugin-transform-es2015-duplicate-keys@^6.24.1:
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-for-of@^6.22.0, babel-plugin-transform-es2015-for-of@^6.23.0:
+babel-plugin-transform-es2015-for-of@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-function-name@^6.22.0, babel-plugin-transform-es2015-function-name@^6.24.1:
+babel-plugin-transform-es2015-function-name@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
   dependencies:
@@ -1222,7 +1212,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-e
     babel-template "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
   dependencies:
@@ -1230,7 +1220,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-e
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015-modules-umd@^6.24.1:
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
   dependencies:
@@ -1238,14 +1228,14 @@ babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-object-super@^6.22.0, babel-plugin-transform-es2015-object-super@^6.24.1:
+babel-plugin-transform-es2015-object-super@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
   dependencies:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.23.0, babel-plugin-transform-es2015-parameters@^6.24.1:
+babel-plugin-transform-es2015-parameters@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -1256,7 +1246,7 @@ babel-plugin-transform-es2015-parameters@^6.23.0, babel-plugin-transform-es2015-
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.22.0, babel-plugin-transform-es2015-shorthand-properties@^6.24.1:
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
@@ -1269,7 +1259,7 @@ babel-plugin-transform-es2015-spread@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-sticky-regex@^6.22.0, babel-plugin-transform-es2015-sticky-regex@^6.24.1:
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
   dependencies:
@@ -1283,13 +1273,13 @@ babel-plugin-transform-es2015-template-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.22.0, babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es2015-unicode-regex@^6.24.1:
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
   dependencies:
@@ -1342,7 +1332,7 @@ babel-plugin-transform-minify-booleans@^6.8.3:
   version "6.8.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.3.tgz#5906ed776d3718250519abf1bace44b0b613ddf9"
 
-babel-plugin-transform-object-rest-spread@6.26.0:
+babel-plugin-transform-object-rest-spread@6.26.0, babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:
@@ -1396,7 +1386,7 @@ babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@6.26.0, babel-plugin-transform-regenerator@^6.24.1, babel-plugin-transform-regenerator@^6.26.0:
+babel-plugin-transform-regenerator@6.26.0, babel-plugin-transform-regenerator@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
   dependencies:
@@ -1489,35 +1479,6 @@ babel-preset-env@1.6.1, babel-preset-env@^1.6.1:
     browserslist "^2.1.2"
     invariant "^2.2.2"
     semver "^5.3.0"
-
-babel-preset-es2015@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
-  dependencies:
-    babel-plugin-check-es2015-constants "^6.22.0"
-    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoping "^6.24.1"
-    babel-plugin-transform-es2015-classes "^6.24.1"
-    babel-plugin-transform-es2015-computed-properties "^6.24.1"
-    babel-plugin-transform-es2015-destructuring "^6.22.0"
-    babel-plugin-transform-es2015-duplicate-keys "^6.24.1"
-    babel-plugin-transform-es2015-for-of "^6.22.0"
-    babel-plugin-transform-es2015-function-name "^6.24.1"
-    babel-plugin-transform-es2015-literals "^6.22.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.1"
-    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
-    babel-plugin-transform-es2015-modules-systemjs "^6.24.1"
-    babel-plugin-transform-es2015-modules-umd "^6.24.1"
-    babel-plugin-transform-es2015-object-super "^6.24.1"
-    babel-plugin-transform-es2015-parameters "^6.24.1"
-    babel-plugin-transform-es2015-shorthand-properties "^6.24.1"
-    babel-plugin-transform-es2015-spread "^6.22.0"
-    babel-plugin-transform-es2015-sticky-regex "^6.24.1"
-    babel-plugin-transform-es2015-template-literals "^6.22.0"
-    babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
-    babel-plugin-transform-es2015-unicode-regex "^6.24.1"
-    babel-plugin-transform-regenerator "^6.24.1"
 
 babel-preset-flow@^6.23.0:
   version "6.23.0"


### PR DESCRIPTION
Fixes #82 

Changes:

- all components refactored to ES6
- tune Babel settings (use `env` preset, etc.), move settings to `.babelrc` file