### PR TITLE
readmore purge

### DIFF
--- a/src/indigo/less/shame.less
+++ b/src/indigo/less/shame.less
@@ -258,32 +258,6 @@ small.empty-label {
   min-height: 100px;
 }
 
-//moved from Readmore.less
-//
-
-//ANALYZA: predelat na 'Show More' koncept
-//https://github.com/keboola/indigo-ui/issues/180
-.kbc-readmore {
-  position: relative;
-  overflow: hidden;
-
-  //Ty nadpisy jsou zbytecny stylovat. Kdyz uz, tak pro Markdown
-  h1 {
-    font-size: 25px;
-  }
-  h2 {
-    font-size: 19px;
-  }
-  h3 {
-    font-weight: bold;
-    font-size: 17px;
-  }
-  h4 {
-    font-weight: bold;
-    font-size: 15px;
-  }
-}
-
 //ANALYZA: nahradit svg ikonkama
 // moved from VersionIcon.less
 .kbc-version-icon {


### PR DESCRIPTION
v keboola aplikacich uz classa '.kbc-readmore' nikde nefiguruje

https://github.com/search?q=org%3Akeboola+kbc-readmore&unscoped_q=kbc-readmore

Na tu classu byly naveseny styly pro nadpisy markdownu, ktery uz se neaplikovali.
Nadpisy maji nyni nove velikosti , nevidim moc duvod pro to, aby markdown nadpissy meli jiny velikosti nez zbytek aplikace.

Predchozi stav (s classou .kbc-readmore)
![image](https://user-images.githubusercontent.com/15363559/45687114-28229b80-bb4e-11e8-8e74-5e3143997106.png)

Soucasny stav (.kbc-readmore styly se neaplikuju, muzeme je vyhodit)
![image](https://user-images.githubusercontent.com/15363559/45687152-42f51000-bb4e-11e8-8176-37c5f2d73f1e.png)

