### PR TITLE
Detail table panel - row margins

### DIFF
--- a/src/indigo/less/panels.less
+++ b/src/indigo/less/panels.less
@@ -87,7 +87,7 @@
 .panel-body > .row {
     margin-top: -25px;
     margin-left: -25px;
-    margin-right: -26px;
+    margin-right: -25px;
     &:last-child {
         margin-bottom: -25px;
     }


### PR DESCRIPTION
fixes https://github.com/keboola/kbc-ui/issues/2122

Myslím, že by mohlo jít o typo. Nebo je důvod proč je tu o 1 pixel více?