### PR TITLE
Table - no margin helper class

### DIFF
--- a/src/indigo/less/shame.less
+++ b/src/indigo/less/shame.less
@@ -755,3 +755,8 @@ small.empty-label {
 .col-searchbar-padded, .col-searchbar-events-padded {
   margin: 10px 0;
 }
+
+// odmazání default margin u bootstrap tabulky
+.table-no-margin {
+    margin: 0;
+}

--- a/src/indigo/less/shame.less
+++ b/src/indigo/less/shame.less
@@ -758,5 +758,5 @@ small.empty-label {
 
 // odmazání default margin u bootstrap tabulky
 .table-no-margin {
-    margin: 0;
+  margin: 0;
 }

--- a/src/indigo/less/tables.less
+++ b/src/indigo/less/tables.less
@@ -151,7 +151,7 @@
 }
 
 .table-marginless {
-  margin: 0px;
+    margin: 0px;
 }
 
 a.tr {

--- a/src/indigo/less/tables.less
+++ b/src/indigo/less/tables.less
@@ -150,10 +150,6 @@
     }
 }
 
-.table-marginless {
-    margin: 0px;
-}
-
 a.tr {
     color: @text-color;
 }

--- a/src/indigo/less/tables.less
+++ b/src/indigo/less/tables.less
@@ -150,6 +150,10 @@
     }
 }
 
+.table-marginless {
+  margin: 0px;
+}
+
 a.tr {
     color: @text-color;
 }


### PR DESCRIPTION
Můžeme použít třeba tu: https://github.com/keboola/kbc-ui/issues/2122

Základní CSS bootstrapu tabulky obsahuje: margin-bottom: 20px. Což nemusí být vždy žádoucí. 