### PR TITLE
Main Content with aside Nav - overflow issue

### DIFF
--- a/src/indigo/less/main-content.less
+++ b/src/indigo/less/main-content.less
@@ -139,8 +139,6 @@
     padding: 0;
 
     > .kbc-container {
-        margin-right: -2px;
-        border-right: 1px solid @table-border-color;
         padding-left: 10px;
         padding-right: 10px;
     }
@@ -198,7 +196,6 @@
     padding: 0;
     border-left: 1px solid @table-border-color;
     position: relative;
-    left: 1px;
     min-height: 90vh;
 }
 

--- a/src/indigo/less/main-content.less
+++ b/src/indigo/less/main-content.less
@@ -139,6 +139,8 @@
     padding: 0;
 
     > .kbc-container {
+        margin-right: -1px;
+        border-right: 1px solid @table-border-color;
         padding-left: 10px;
         padding-right: 10px;
     }


### PR DESCRIPTION
fixes: #283

Nav má sice border-right, ale je tam spíše navíc. Navíc není 100% výšky. Content vpravo má border-left přes celou výšku. Takže to zastoupí.
Vyřeší se tím i ten problém se scrollbarem. Protože teď to tam nějak nevychází.