### PR TITLE
Overview component - horizontal Scrollbar

### DIFF
--- a/src/indigo/less/components.less
+++ b/src/indigo/less/components.less
@@ -6,7 +6,7 @@
             vertical-align: top;
             border-right: solid 1px @table-border-color;
             &:nth-child(3):nth-last-child(1) {
-                border-right: none;
+                border-right: solid 1px transparent;
             }
             .kb-sapi-component-icon {
                 padding: 0;


### PR DESCRIPTION
Koukal jsem že v sekci /limits a /applications máme další scrollbar dole.

Vypadá to, že prohlížeč (min. Chrome) má problém s tím, že ty 3 boxy jsou různé. Dva mají border a u třetího není. Chrome pak asi špatně vypočítá tu velikost a zobrazí scrollbar.

Fix je asi trochu "hack" ale vypadá, že to funguje. Místo toho aby jsme ten poslední border odstranily ho uděláme průhledným. Pak jsou všechny boxy stejné a scrollbar zmizí.