### PR TITLE
Add btn-link-inline class and sample story

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -19,6 +19,7 @@ function loadStories() {
   require('../src/stories/Popover');
   require('../src/stories/RegionSelector');
   require('../src/stories/ModalConfiguration');
+  require('../src/stories/BtnLinkInline');
   require('../src/stories/ExternalLink');
   require('../src/stories/PanelWithDetails');
   require('../src/stories/AlertBlock');

--- a/src/indigo/less/buttons.less
+++ b/src/indigo/less/buttons.less
@@ -6,7 +6,22 @@ button {
     color: @kbc-btn-default-color;
 }
 .btn {
-    padding: 7px 12px;
+  padding: 7px 12px;
+  &-link {
+    color: @gray;
+
+    // Inline button
+    &-inline {
+      padding: 0;
+      border: none;
+      color: @link-hover-color;
+      display: inline;
+      vertical-align: inherit;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 }
 .btn-lg, .btn-group-lg>.btn {
     padding: 12px 20px;
@@ -39,9 +54,6 @@ button {
     margin-left: -2px;
 }
 
-.btn-link {
-    color: @gray;
-}
 .kbc-btn-link-icon {
     &:extend(.btn-link);
     &:hover,

--- a/src/stories/BtnLinkInline/index.js
+++ b/src/stories/BtnLinkInline/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+import {action} from '@storybook/addon-actions';
+
+storiesOf('[CSS] Inline button', module)
+  .add(
+    'Inline button',
+    withInfo({
+      text: `
+        Add **btn-link-inline** class to render inline button which looks like link.
+        `,
+      inline: true,
+    })(() => {
+      return (
+        <div>
+          <p>
+            For more information please{' '}
+            <button className="btn btn-link btn-link-inline" onClick={action('inlined button clicked')}>contact us</button>.
+          </p>
+        </div>
+      );
+    })
+  );


### PR DESCRIPTION
Fixes #297 

Changes:

- reorganize less (stylelint)
- add new `btn-link-inline` class to allow inline button
- add story/sample