### PR TITLE
Modal open - padding to top-navbar-fixed

### DIFF
--- a/src/indigo/less/shame.less
+++ b/src/indigo/less/shame.less
@@ -675,3 +675,10 @@ small.empty-label {
 .table-no-margin {
   margin: 0;
 }
+
+// fixes: https://github.com/keboola/kbc-ui/issues/1461
+// bootstrap přidává automaticky padding-right 17px pro body při otevřeném modalu to ale neplatí
+// pro navbar-fixed-top, který je pozicován fixně, je teda potřeba přidat padding přímo i tam
+body.modal-open .navbar-fixed-top.kbc-navbar {
+  padding-right: 17px;
+}


### PR DESCRIPTION
fixes: https://github.com/keboola/kbc-ui/issues/1461

Není to hotfix ale beztak jsem to hodil do shame.less, protože se mi to nezdá jako nejlepší fix. Nevím kde i bootstrap bere těch 17px co přidává to style body. Jestli to vypočítává při otevřené modalu nebo při inicializaci bootstrapu, pak tato úprava nemusí sedět (pokud by měl někdo ten scrollbar jiný jak 17px co je u mě).