### PR TITLE
Add new helper class - kbc-break-word

### DIFF
--- a/src/indigo/less/type.less
+++ b/src/indigo/less/type.less
@@ -77,8 +77,10 @@ a {
     word-break: break-all;
 }
 .kbc-break-word {
-    word-break: break-all;
     word-break: break-word;
+}
+.kbc-overflow-break-word {
+  overflow-wrap: break-word;
 }
 
 

--- a/src/indigo/less/type.less
+++ b/src/indigo/less/type.less
@@ -76,6 +76,10 @@ a {
 .kbc-break-all {
     word-break: break-all;
 }
+.kbc-break-word {
+    word-break: break-all;
+    word-break: break-word;
+}
 
 
 body {


### PR DESCRIPTION
Fixes: #183

related https://github.com/keboola/kbc-ui/issues/1354

Jde o to: že 
```css
word-break: break-word;
```
není cross browser podporované. Firefox toto ignoruje (alespoň test v novém Firefoxu). V KBC-UI to je použito ale na dosti místech (viz i issue). Bude lepší asi použít tuto třídu a v případě jako fallback použít "break-all", než aby se třeba ovládací tlačítka posunuli mimo obrazovku.

Jinak `break-word` je použito i na jiných místěch zde v Indigo-ui. Tak by asi stálo za to to projet a případně taky přidat fallbeck nebo nějak jinak vyřešit.