### PR TITLE
InlineEditInput - css

### DIFF
--- a/src/indigo/less/inline-edit-input.less
+++ b/src/indigo/less/inline-edit-input.less
@@ -8,11 +8,9 @@
   }
 
   &-buttons {
-    display: flex;
-    align-items: center;
     position: absolute;
     right: 4px;
-    top: -4px;
+    top: -3px;
 
     .fa-spin {
       position: absolute;
@@ -24,7 +22,7 @@
 
   &-cancel {
     padding: 0 5px 0 5px;
-    font-size: 18px;
+    font-size: 17px;
     color: #e1e1e9;
 
     &:hover,
@@ -71,7 +69,6 @@
     display: inline-block;
     width: auto;
     padding: 6px 80px 6px 12px;
-    vertical-align: middle;
 
     &:disabled {
       border-color: @input-border;


### PR DESCRIPTION
Tak ještě jedno kolo CSS.

Flexbox jsem koukal že nemá žádný vliv tam, tak jsem to smazal.
Zajímavý je ten input "vertical-align: middle;" - toto nějak podivně hýbe s celým řádkem, jak tu ve storybook tak s celou drobečkovkou v KBC-UI.
Tlačítku na reset jsem dal menší velikost. Pak má button i ten reset stejnou výšku 26px, což snad trošku pomůže s tím vystředěním, ale na stopro to není. Ještě by bylo možné nechat velikost a upravit line-height. Klidně upravím.

Před:
![pred](https://user-images.githubusercontent.com/12331181/49573724-ffd15e80-f93e-11e8-8d8c-f62434345390.png)

Po:
![po](https://user-images.githubusercontent.com/12331181/49573733-03fd7c00-f93f-11e8-8b8f-f8735cfa3445.png)