### PR TITLE
Remove vertical alignment from first cell in sidebar lists

### DIFF
--- a/src/indigo/less/main-content.less
+++ b/src/indigo/less/main-content.less
@@ -72,7 +72,6 @@
         background: none;
         color: #282d38;
         .table > .tr > .td {
-            vertical-align: top;
             &:first-child {
                 padding-left: 0;
                 padding-right: 10px;


### PR DESCRIPTION
Related to #316 

Changes

- remove vertical alignment (top) from first item, to make icon centered