### PR TITLE
Set text-align and white-space to initial values for inline btn

### DIFF
--- a/src/indigo/less/buttons.less
+++ b/src/indigo/less/buttons.less
@@ -20,6 +20,8 @@ button {
       &:hover {
         text-decoration: underline;
       }
+      text-align: start;
+      white-space: normal;
     }
   }
 }


### PR DESCRIPTION
Fixes #360 