### PR TITLE
Tree component - padding

### DIFF
--- a/src/indigo/less/tables.less
+++ b/src/indigo/less/tables.less
@@ -119,7 +119,7 @@
     .kb-tree {
       overflow: hidden;
 
-      ul {
+      ul ul {
         padding-left: 20px;
       }
     }

--- a/src/indigo/less/tables.less
+++ b/src/indigo/less/tables.less
@@ -117,7 +117,11 @@
     }
 
     .kb-tree {
-        overflow: hidden;
+      overflow: hidden;
+
+      ul {
+        padding-left: 20px;
+      }
     }
 }
 


### PR DESCRIPTION
Myslím že by bylo lepší udělat ten strom trochu více "kompaktní". I pro přehlednost se mi to líbí více, jako bonus na řádek se vejde více informací.

Třeba job detail:

Před:
![pred](https://user-images.githubusercontent.com/12331181/56267281-b3690d00-60ee-11e9-9b64-2cc9762c8a62.png)

Po:
![po](https://user-images.githubusercontent.com/12331181/56267285-b5cb6700-60ee-11e9-9859-4c993e10e0e0.png)

Nakonec jsem to dal od druhé úrovně, aby pro úvodní list byl padding stejný jako když tuto komponentu nepoužiji. Až od druhé úrovně to pak bude kompaktnější.