### PR TITLE
Use flexbox for react-select

### DIFF
--- a/src/indigo/less/react-select.less
+++ b/src/indigo/less/react-select.less
@@ -1,18 +1,34 @@
 @import (inline) '@{libsPath}react-select/dist/react-select.css';
 
-// due to codemirror
-.Select-menu-outer {
-  z-index: 5;
-}
+.Select {
+  // Use flexbox because "display: table" can not handle half pixels correctly
+  .Select-control {
+    display: flex;
+    align-items: center;
 
-.Select-input {
-  width: 100%;
-  display: inline!important;
-  > input {
-    padding: 8px 0 10px;
+    & > .Select-multi-value-wrapper {
+      flex: 1 1 0%;
+    }
+
+    & > .Select-arrow-zone {
+      display: inline-block;
+    }
   }
-}
 
-.Select-option {
-  word-wrap: break-word;
+  // due to codemirror
+  .Select-menu-outer {
+    z-index: 5;
+  }
+
+  .Select-input {
+    display: inline !important;
+
+    > input {
+      padding: 8px 0 10px;
+    }
+  }
+
+  .Select-option {
+    word-wrap: break-word;
+  }
 }


### PR DESCRIPTION
Fixed https://github.com/keboola/kbc-ui/issues/3256

React-select v1 používá `display: table`, který neumí pak právě řešit ty půl pixely apod. Což může dělat ty problémy. Bude to asi na více místech když máme `width: 100%`, tam se snadno stane že ty pixely nejsou zaokrouhlené.

Klikal jsem v KBC-UI a takto to vypadá všude ok, trošku mě překvapuje že ikdyž není select multi, furt tam je třída `Select-multi-value-wrapper` ale asi to tak prostě je.