### PR TITLE
Project list styling - min width

### DIFF
--- a/src/indigo/less/new-ui/header.less
+++ b/src/indigo/less/new-ui/header.less
@@ -108,6 +108,11 @@
         left: 10px;
         right: 20px;
         padding: 15px;
+        min-width: 220px;
+
+        .searchbar-input {
+          padding-right: 34px;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/keboola/kbc-ui/issues/3509

- jen přidaná minimální velikost toho dropdown-menu 
- o pidi menší padding inputu

Tady jsou dvě varianty. MinWidth pro dropdown jako to je teď, což je hezčí bez rozkliknutí protože ta šipečka je hezky rovnoměrně za názvem projektu. Nebo minWidtn nahoru k jménu třeba, a pak bude dropdown hezky pod tou ikonkou, ale zase bez rozkliknutí bude divně daleko vpravo. Mě se líbí spíš ta první varianta tak jsem ji nahodil, ale dyštak upravím.