### PR TITLE
Firefox - fix login placeholders

### DIFF
--- a/src/indigo/less/new-ui/login.less
+++ b/src/indigo/less/new-ui/login.less
@@ -100,7 +100,12 @@
       }
 
       &:focus + .form-control-placeholder,
-      &:valid + .form-control-placeholder,
+      &:valid + .form-control-placeholder {
+        font-size: 80%;
+        transform: translate3d(0, -100%, 0);
+        opacity: 1;
+      }
+
       &:-webkit-autofill + .form-control-placeholder {
         font-size: 80%;
         transform: translate3d(0, -100%, 0);


### PR DESCRIPTION
Pokud mám `:-webkit-autofill` rovnou přilepené u `:focus` a `:valid`, tak firefox ignoruje celý ten blok. Nerozumím proč. Když to takto oddělím tak to funguje ok (valid pokryje asi i ten autofill u Firefoxu to vypadá).