### PR TITLE
Terminated job - change status "dot" color

### DIFF
--- a/src/indigo/components/JobStatusCircle.js
+++ b/src/indigo/components/JobStatusCircle.js
@@ -8,7 +8,7 @@ const statusColorMap = {
   warning: 'danger',
   processing: 'warning',
   waiting: 'default',
-  canceled: 'canceled',
+  cancelled: 'canceled',
   terminating: 'canceled',
   terminated: 'canceled',
 };

--- a/src/indigo/components/JobStatusCircle.js
+++ b/src/indigo/components/JobStatusCircle.js
@@ -7,10 +7,10 @@ const statusColorMap = {
   warn: 'danger',
   warning: 'danger',
   processing: 'warning',
-  cancelled: 'default',
   waiting: 'default',
-  terminating: 'default',
-  terminated: 'default',
+  canceled: 'canceled',
+  terminating: 'canceled',
+  terminated: 'canceled',
 };
 
 class JobStatusCircle extends React.Component {

--- a/src/indigo/components/JobStatusCircle.test.js
+++ b/src/indigo/components/JobStatusCircle.test.js
@@ -4,8 +4,8 @@ import { snapshot } from '../../tests';
 import JobStatusCircle from './JobStatusCircle';
 
 describe('<JobStatusCircle />', () => {
-  it('Job Status - Canceled', () => {
-    snapshot(<JobStatusCircle status="canceled" />);
+  it('Job Status - Cancelled', () => {
+    snapshot(<JobStatusCircle status="cancelled" />);
   });
 
   it('Job Status - Success', () => {

--- a/src/indigo/components/JobStatusCircle.test.js
+++ b/src/indigo/components/JobStatusCircle.test.js
@@ -4,8 +4,8 @@ import { snapshot } from '../../tests';
 import JobStatusCircle from './JobStatusCircle';
 
 describe('<JobStatusCircle />', () => {
-  it('Job Status - Cancelled', () => {
-    snapshot(<JobStatusCircle status="cancelled" />);
+  it('Job Status - Canceled', () => {
+    snapshot(<JobStatusCircle status="canceled" />);
   });
 
   it('Job Status - Success', () => {
@@ -18,6 +18,10 @@ describe('<JobStatusCircle />', () => {
 
   it('Job Status - Warning', () => {
     snapshot(<JobStatusCircle status="processing" />);
+  });
+
+  it('Job Status - Terminated', () => {
+    snapshot(<JobStatusCircle status="terminated" />);
   });
 
   it('Job Status - not provided', () => {

--- a/src/indigo/components/__snapshots__/JobStatusCircle.test.js.snap
+++ b/src/indigo/components/__snapshots__/JobStatusCircle.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<JobStatusCircle /> Job Status - Canceled 1`] = `
+exports[`<JobStatusCircle /> Job Status - Cancelled 1`] = `
 <i
   className="fa fa-circle job-status-circle-canceled"
 />

--- a/src/indigo/components/__snapshots__/JobStatusCircle.test.js.snap
+++ b/src/indigo/components/__snapshots__/JobStatusCircle.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<JobStatusCircle /> Job Status - Cancelled 1`] = `
+exports[`<JobStatusCircle /> Job Status - Canceled 1`] = `
 <i
-  className="fa fa-circle job-status-circle-default"
+  className="fa fa-circle job-status-circle-canceled"
 />
 `;
 
@@ -15,6 +15,12 @@ exports[`<JobStatusCircle /> Job Status - Error 1`] = `
 exports[`<JobStatusCircle /> Job Status - Success 1`] = `
 <i
   className="fa fa-circle job-status-circle-success"
+/>
+`;
+
+exports[`<JobStatusCircle /> Job Status - Terminated 1`] = `
+<i
+  className="fa fa-circle job-status-circle-canceled"
 />
 `;
 

--- a/src/indigo/less/job-status-circle.less
+++ b/src/indigo/less/job-status-circle.less
@@ -11,4 +11,7 @@
   &-warning {
     color: @label-warning-bg
   }
+  &-canceled {
+    color: #000;
+  }
 }


### PR DESCRIPTION
Přidal jsem styl `canceled`. Ještě tam bylo typo `cancelled` (dvě L) nevím zda schválně historicky nebo to bylo právě typo. Ale opravil jsem to. Po pravdě ani nevím zda máme status `canceled` zda není pouze `terminated`.

Každopándě právě pro `terminated`, `terminatting` a `canceled` tam je nový styl. Černé kolečko. Je to stejné jako má `cancel` label.