### PR TITLE
Replace custom kbc-icon icons

### DIFF
--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -48,7 +48,7 @@ class InlineEditTextInput extends React.Component {
               disabled={this.props.isSaving}
               onClick={this.props.onEditCancel}
             >
-              <span className="kbc-icon-cross" />
+              <i className="fa fa-fw fa-times-circle" />
             </Button>
             <Button
               className="inline-edit-input-submit"
@@ -77,7 +77,7 @@ class InlineEditTextInput extends React.Component {
           ) : (
             <span className="text-muted">{this.props.placeholder}</span>
           )}
-          <span className="kbc-icon-pencil" />
+          <i className="fa fa-fw fa-pencil" />
         </span>
       </OverlayTrigger>
     );

--- a/src/indigo/components/Loader.js
+++ b/src/indigo/components/Loader.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 class Loader extends React.Component {
   render() {
-    return <span className={classNames('fa fa-fw fa-spin fa-spinner', this.props.className)} />;
+    return <i className={classNames('fa fa-fw fa-spin fa-spinner', this.props.className)} />;
   }
 }
 

--- a/src/indigo/components/Loader.js
+++ b/src/indigo/components/Loader.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 class Loader extends React.Component {
   render() {
-    return <span className={classNames('fa fa-spin fa-spinner', this.props.className)} />;
+    return <span className={classNames('fa fa-fw fa-spin fa-spinner', this.props.className)} />;
   }
 }
 

--- a/src/indigo/components/RefreshIcon.js
+++ b/src/indigo/components/RefreshIcon.js
@@ -8,7 +8,11 @@ class RefreshIcon extends React.Component {
     const { isLoading, title, ...remaining } = this.props;
     return (
       <span title={title}>
-        {isLoading ? <Loader /> : <span {...remaining} className="kbc-refresh kbc-icon-cw" />}
+        {isLoading ? (
+          <Loader />
+        ) : (
+          <span {...remaining} className="kbc-refresh fa fa-fw fa-refresh" />
+        )}
       </span>
     );
   }

--- a/src/indigo/components/RefreshIcon.js
+++ b/src/indigo/components/RefreshIcon.js
@@ -8,11 +8,7 @@ class RefreshIcon extends React.Component {
     const { isLoading, title, ...remaining } = this.props;
     return (
       <span title={title}>
-        {isLoading ? (
-          <Loader />
-        ) : (
-          <span {...remaining} className="kbc-refresh fa fa-fw fa-refresh" />
-        )}
+        {isLoading ? <Loader /> : <i {...remaining} className="kbc-refresh fa fa-fw fa-refresh" />}
       </span>
     );
   }

--- a/src/indigo/components/__snapshots__/ConfirmButtons.test.js.snap
+++ b/src/indigo/components/__snapshots__/ConfirmButtons.test.js.snap
@@ -208,8 +208,8 @@ exports[`<Check /> Saving 1`] = `
   className="btn-toolbar-confirm btn-toolbar"
   role="toolbar"
 >
-  <span
-    className="fa fa-spin fa-spinner"
+  <i
+    className="fa fa-fw fa-spin fa-spinner"
   />
   <button
     className="btn-confirm btn btn-link"

--- a/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
+++ b/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
@@ -14,8 +14,8 @@ exports[`<InlineEditInput /> InlineEditInput - default 1`] = `
   >
     Click to edit
   </span>
-  <span
-    className="kbc-icon-pencil"
+  <i
+    className="fa fa-fw fa-pencil"
   />
 </span>
 `;
@@ -45,8 +45,8 @@ exports[`<InlineEditInput /> InlineEditInput - disabled save button when text is
         onClick={[Function]}
         type="button"
       >
-        <span
-          className="kbc-icon-cross"
+        <i
+          className="fa fa-fw fa-times-circle"
         />
       </button>
       <button
@@ -86,8 +86,8 @@ exports[`<InlineEditInput /> InlineEditInput - edit mode 1`] = `
         onClick={[Function]}
         type="button"
       >
-        <span
-          className="kbc-icon-cross"
+        <i
+          className="fa fa-fw fa-times-circle"
         />
       </button>
       <button
@@ -116,8 +116,8 @@ exports[`<InlineEditInput /> InlineEditInput - read mode 1`] = `
   >
     Click to edit
   </span>
-  <span
-    className="kbc-icon-pencil"
+  <i
+    className="fa fa-fw fa-pencil"
   />
 </span>
 `;
@@ -147,8 +147,8 @@ exports[`<InlineEditInput /> InlineEditInput - saving in edit mode 1`] = `
         onClick={[Function]}
         type="button"
       >
-        <span
-          className="kbc-icon-cross"
+        <i
+          className="fa fa-fw fa-times-circle"
         />
       </button>
       <button

--- a/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
+++ b/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
@@ -158,8 +158,8 @@ exports[`<InlineEditInput /> InlineEditInput - saving in edit mode 1`] = `
       >
         Save
       </button>
-      <span
-        className="fa fa-spin fa-spinner"
+      <i
+        className="fa fa-fw fa-spin fa-spinner"
       />
     </div>
   </form>

--- a/src/indigo/components/__snapshots__/Loader.test.js.snap
+++ b/src/indigo/components/__snapshots__/Loader.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Loader /> Loader - default 1`] = `
-<span
-  className="fa fa-spin fa-spinner"
+<i
+  className="fa fa-fw fa-spin fa-spinner"
 />
 `;
 
 exports[`<Loader /> Loader - with classname 1`] = `
-<span
-  className="fa fa-spin fa-spinner additional-class"
+<i
+  className="fa fa-fw fa-spin fa-spinner additional-class"
 />
 `;

--- a/src/indigo/components/__snapshots__/RefreshIcon.test.js.snap
+++ b/src/indigo/components/__snapshots__/RefreshIcon.test.js.snap
@@ -25,7 +25,7 @@ exports[`<RefreshIcon /> RefreshIcon - not loading 1`] = `
   title="Refresh"
 >
   <span
-    className="kbc-refresh kbc-icon-cw"
+    className="kbc-refresh fa fa-fw fa-refresh"
   />
 </span>
 `;

--- a/src/indigo/components/__snapshots__/RefreshIcon.test.js.snap
+++ b/src/indigo/components/__snapshots__/RefreshIcon.test.js.snap
@@ -4,8 +4,8 @@ exports[`<RefreshIcon /> RefreshIcon - loading 1`] = `
 <span
   title="Refresh"
 >
-  <span
-    className="fa fa-spin fa-spinner"
+  <i
+    className="fa fa-fw fa-spin fa-spinner"
   />
 </span>
 `;
@@ -14,8 +14,8 @@ exports[`<RefreshIcon /> RefreshIcon - loading with custom title 1`] = `
 <span
   title="Click to reload"
 >
-  <span
-    className="fa fa-spin fa-spinner"
+  <i
+    className="fa fa-fw fa-spin fa-spinner"
   />
 </span>
 `;

--- a/src/indigo/components/__snapshots__/RefreshIcon.test.js.snap
+++ b/src/indigo/components/__snapshots__/RefreshIcon.test.js.snap
@@ -24,7 +24,7 @@ exports[`<RefreshIcon /> RefreshIcon - not loading 1`] = `
 <span
   title="Refresh"
 >
-  <span
+  <i
     className="kbc-refresh fa fa-fw fa-refresh"
   />
 </span>


### PR DESCRIPTION
Related #405 

Ještě vyhození kbc-icon z Indigo-ui. Pak už asi půjde vyhodit ty CSS.

EDIT: Přidal jsem `fa-fw` k Loaderu. Máme to u většiny ikon tak to bude lepší. Nedochází pak třeba u Refresh komponenty ke skákání té ikonky, protože takto budou mít stejnou šířku.