### PR TITLE
Remove usages of custom react components icons

### DIFF
--- a/src/indigo/components/AlertBlock.js
+++ b/src/indigo/components/AlertBlock.js
@@ -2,9 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from 'react-bootstrap';
 
-import IconWarning from './icons/Warning';
-import IconDanger from './icons/Danger';
-
 class AlertBlock extends React.Component {
   render() {
     const { type, title, children } = this.props;
@@ -12,18 +9,11 @@ class AlertBlock extends React.Component {
       <Alert className="alert-block" bsStyle={type}>
         <h3 className="alert-block-title">{title}</h3>
         <div className="alert-block-body">
-          {this.renderIcon()}
+          <i className="fa fa-exclamation-triangle" />
           {children}
         </div>
       </Alert>
     );
-  }
-
-  renderIcon() {
-    if (this.props.type === 'warning') {
-      return <IconWarning className="alert-block-icon" />;
-    }
-    return <IconDanger className="alert-block-icon" />;
   }
 }
 

--- a/src/indigo/components/SearchBar.js
+++ b/src/indigo/components/SearchBar.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { FormControl, Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Icon from './icons';
 
 class SearchBar extends React.Component {
   constructor(props) {
@@ -68,10 +67,10 @@ class SearchBar extends React.Component {
               }
             }}
           />
-          <Icon.Search className="searchbar-icon icon-size-20" />
+          <i className="fa fa-search" />
           {this.props.query && (
             <Button bsStyle="link" className="searchbar-clear-btn" onClick={this.handleClear}>
-              <Icon.Times className="searchbar-clear-icon icon-size-16" />
+              <i className="fa fa-times" />
             </Button>
           )}
         </form>

--- a/src/indigo/components/__snapshots__/AlertBlock.test.js.snap
+++ b/src/indigo/components/__snapshots__/AlertBlock.test.js.snap
@@ -13,25 +13,9 @@ exports[`<AlertBlock /> AlertBlock - danger 1`] = `
   <div
     className="alert-block-body"
   >
-    <svg
-      className="icon alert-block-icon"
-      height="19"
-      viewBox="0 0 22 19"
-      width="22"
-    >
-      <g
-        fill="none"
-        fillRule="evenodd"
-      >
-        <path
-          d="M-1-2h24v24H-1z"
-        />
-        <path
-          d="M0 19h22L11 0 0 19zm12-3h-2v-2h2v2zm0-4h-2V8h2v4z"
-          fill="currentColor"
-        />
-      </g>
-    </svg>
+    <i
+      className="fa fa-exclamation-triangle"
+    />
     Danger text
   </div>
 </div>
@@ -50,25 +34,9 @@ exports[`<AlertBlock /> AlertBlock - warning 1`] = `
   <div
     className="alert-block-body"
   >
-    <svg
-      className="icon alert-block-icon"
-      height="20"
-      viewBox="0 0 20 20"
-      width="20"
-    >
-      <g
-        fill="none"
-        fillRule="evenodd"
-      >
-        <path
-          d="M-2-2h24v24H-2z"
-        />
-        <path
-          d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm1 15H9v-2h2v2zm0-4H9V5h2v6z"
-          fill="currentColor"
-        />
-      </g>
-    </svg>
+    <i
+      className="fa fa-exclamation-triangle"
+    />
     Warning text
   </div>
 </div>

--- a/src/indigo/components/__snapshots__/SearchBar.test.js.snap
+++ b/src/indigo/components/__snapshots__/SearchBar.test.js.snap
@@ -17,18 +17,9 @@ exports[`<SearchBar /> SearchBar - inverse theme 1`] = `
       type="text"
       value=""
     />
-    <svg
-      className="icon searchbar-icon icon-size-20"
-      height="32"
-      viewBox="0 0 18 18"
-      width="32"
-    >
-      <path
-        d="M12.5 11h-.79l-.28-.27A6.471 6.471 0 0 0 13 6.5 6.5 6.5 0 1 0 6.5 13c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L17.49 16l-4.99-5zm-6 0C4.01 11 2 8.99 2 6.5S4.01 2 6.5 2 11 4.01 11 6.5 8.99 11 6.5 11z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
+    <i
+      className="fa fa-search"
+    />
     
   </form>
 </div>
@@ -51,18 +42,9 @@ exports[`<SearchBar /> SearchBar - with one additional button 1`] = `
       type="text"
       value=""
     />
-    <svg
-      className="icon searchbar-icon icon-size-20"
-      height="32"
-      viewBox="0 0 18 18"
-      width="32"
-    >
-      <path
-        d="M12.5 11h-.79l-.28-.27A6.471 6.471 0 0 0 13 6.5 6.5 6.5 0 1 0 6.5 13c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L17.49 16l-4.99-5zm-6 0C4.01 11 2 8.99 2 6.5S4.01 2 6.5 2 11 4.01 11 6.5 8.99 11 6.5 11z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
+    <i
+      className="fa fa-search"
+    />
     
   </form>
   <div
@@ -94,18 +76,9 @@ exports[`<SearchBar /> SearchBar - with two additional buttons 1`] = `
       type="text"
       value=""
     />
-    <svg
-      className="icon searchbar-icon icon-size-20"
-      height="32"
-      viewBox="0 0 18 18"
-      width="32"
-    >
-      <path
-        d="M12.5 11h-.79l-.28-.27A6.471 6.471 0 0 0 13 6.5 6.5 6.5 0 1 0 6.5 13c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L17.49 16l-4.99-5zm-6 0C4.01 11 2 8.99 2 6.5S4.01 2 6.5 2 11 4.01 11 6.5 8.99 11 6.5 11z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
+    <i
+      className="fa fa-search"
+    />
     
   </form>
   <div
@@ -142,18 +115,9 @@ exports[`<SearchBar /> SearchBar 1`] = `
       type="text"
       value=""
     />
-    <svg
-      className="icon searchbar-icon icon-size-20"
-      height="32"
-      viewBox="0 0 18 18"
-      width="32"
-    >
-      <path
-        d="M12.5 11h-.79l-.28-.27A6.471 6.471 0 0 0 13 6.5 6.5 6.5 0 1 0 6.5 13c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L17.49 16l-4.99-5zm-6 0C4.01 11 2 8.99 2 6.5S4.01 2 6.5 2 11 4.01 11 6.5 8.99 11 6.5 11z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
+    <i
+      className="fa fa-search"
+    />
     
   </form>
 </div>

--- a/src/indigo/less/alerts.less
+++ b/src/indigo/less/alerts.less
@@ -45,14 +45,6 @@
     font-weight: bold;
   }
 
-  &-icon {
-    position: absolute;
-    top: 25px;
-    right: 25px;
-    width: 84px;
-    height: auto;
-  }
-
   a {
     color: #7C8498;
     &:hover {
@@ -78,11 +70,18 @@
     }
   }
 
+  .fa-exclamation-triangle {
+    position: absolute;
+    top: 25px;
+    right: 25px;
+    font-size: 6em;
+  }
+
   &.alert-warning {
     background-color: #FFF6DC;
     border-color: #FFD452;
 
-    .alert-block-icon {
+    .fa-exclamation-triangle {
       color: #FFD452;
     }
 
@@ -95,7 +94,7 @@
     background-color: #FEEDEF;
     border-color: #F74D63;
 
-    .alert-block-icon {
+    .fa-exclamation-triangle {
       color: #f74d63;
     }
 

--- a/src/indigo/less/alerts.less
+++ b/src/indigo/less/alerts.less
@@ -45,6 +45,14 @@
     font-weight: bold;
   }
 
+  &-icon {
+    position: absolute;
+    top: 25px;
+    right: 25px;
+    width: 84px;
+    height: auto;
+  }
+
   a {
     color: #7C8498;
     &:hover {
@@ -81,6 +89,7 @@
     background-color: #FFF6DC;
     border-color: #FFD452;
 
+    .alert-block-icon,
     .fa-exclamation-triangle {
       color: #FFD452;
     }
@@ -94,6 +103,7 @@
     background-color: #FEEDEF;
     border-color: #F74D63;
 
+    .alert-block-icon,
     .fa-exclamation-triangle {
       color: #f74d63;
     }

--- a/src/indigo/less/search.less
+++ b/src/indigo/less/search.less
@@ -25,24 +25,32 @@
     }
   }
 
-  &-icon {
+  &-clear-btn {
+    display: flex;
+    position: absolute;
+    right: 0px;
+    
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+
+  .fa-search {
     position: absolute;
     left: 10px;
     color: @kbc-grey-3;
+    font-size: 1.35em;
   }
 
-  &-clear {
-    &-btn {
-      display: flex;
-      position: absolute;
-      right: 0px;
-    }
-    &-icon {
-      color: inherit
-    }
+  .fa-times {
+    color: inherit;
+    font-size: 1.5em;
   }
+
   &-inverse {
-    .searchbar-icon {
+    .fa-search {
       color: #7f8188;
     }
 

--- a/src/indigo/less/search.less
+++ b/src/indigo/less/search.less
@@ -25,15 +25,25 @@
     }
   }
 
-  &-clear-btn {
-    display: flex;
+  &-icon {
     position: absolute;
-    right: 0px;
-    
+    left: 10px;
+    color: @kbc-grey-3;
+  }
 
-    &:hover,
-    &:focus {
-      text-decoration: none;
+  &-clear {
+    &-btn {
+      display: flex;
+      position: absolute;
+      right: 0px;
+
+      &:hover,
+      &:focus {
+        text-decoration: none;
+      }
+    }
+    &-icon {
+      color: inherit
     }
   }
 
@@ -50,6 +60,7 @@
   }
 
   &-inverse {
+    .searchbar-icon,
     .fa-search {
       color: #7f8188;
     }


### PR DESCRIPTION
Fixed #406 

Mažu jen to použití, ty ikonky pak vyhodíme asi naráz..

Do toho `AlertBlock` jsem hodil stejnou ikonku pro oba stavy, myslím že to je v poho. Liší se pak barvou:
![alerts](https://user-images.githubusercontent.com/12331181/62888070-db841800-bd3e-11e9-9f57-67bfc248aaf9.png)

Search by měl vypadat skoro stejně. Křížek asi jen trochu "mohutnější".