### PR TITLE
Margin & Padding classes

### DIFF
--- a/src/indigo/less/indigo.less
+++ b/src/indigo/less/indigo.less
@@ -34,6 +34,7 @@
 @import "@{libsPath}bootstrap/less/responsive-utilities.less";
 
 @import "variables.less";
+@import "utilities/spacing.less";
 
 @import "alerts.less"; // copy from bootstrap with calc fix + own styles
 @import "buttons.less";

--- a/src/indigo/less/utilities/spacing.less
+++ b/src/indigo/less/utilities/spacing.less
@@ -1,0 +1,55 @@
+.make-spacing-classes(@n, @i: 0) when (@i =< @n) {
+  @base: 1em;
+
+  .m-@{n} {
+    margin: @n * @base !important;
+  }
+  .mt-@{n} {
+    margin-top: @n * @base !important;
+  }
+  .mr-@{n} {
+    margin-right: @n * @base !important;
+  }
+  .mb-@{n} {
+    margin-bottom: @n * @base !important;
+  }
+  .ml-@{n} {
+    margin-left: @n * @base !important;
+  }
+  .mx-@{n} {
+    margin-left: @n * @base !important;
+    margin-right: @n * @base !important;
+  }
+  .my-@{n} {
+    margin-top: @n * @base !important;
+    margin-bottom: @n * @base !important;
+  }
+
+  .p-@{n} {
+    padding: @n * @base !important;
+  }
+  .pt-@{n} {
+    padding-top: @n * @base !important;
+  }
+  .pr-@{n} {
+    padding-right: @n * @base !important;
+  }
+  .pb-@{n} {
+    padding-bottom: @n * @base !important;
+  }
+  .pl-@{n} {
+    padding-left: @n * @base !important;
+  }
+  .px-@{n} {
+    padding-left: @n * @base !important;
+    padding-right: @n * @base !important;
+  }
+  .py-@{n} {
+    padding-top: @n * @base !important;
+    padding-bottom: @n * @base !important;
+  }
+
+  .make-spacing-classes(@n - 1);
+}
+
+.make-spacing-classes(2);


### PR DESCRIPTION
Fixes #417

Vycházel jsem teda z toho co si připravil.

- varianty 2,1 a 0
- přidaný !important - pokud už tuto třídu použiji tak tu marginy tak přesně chci, tak to dává smysl, pokud by mě to mělo něco přepsat tak to tam vůbec nemusí dávat.. myslím že to tak má i bootstrap 4
- jednotku skipu jsem tam 1em - v kbc-ui máme zatím pouze 0,1,2 tak nemá cenu asi generovat nic navíc, dyštak se upraví