### PR TITLE
SearchBar - CSS

### DIFF
--- a/src/indigo/less/components/searchbar.less
+++ b/src/indigo/less/components/searchbar.less
@@ -44,7 +44,8 @@
     display: flex;
     flex-flow: row;
     align-items: center;
-    & > * {
+
+    & > *:not(:empty) {
       margin-left: 8px;
     }
   }


### PR DESCRIPTION
Pokud mám jako `additionalAction` nějaký tlačítko s modalem, tak tam může být třeba prázdny span, na takové prvky nechci aplikovat margin.
 
Related https://github.com/keboola/kbc-ui/pull/3807