### PR TITLE
Buttons have no border, except a btn-default

### DIFF
--- a/src/indigo/less/buttons.less
+++ b/src/indigo/less/buttons.less
@@ -28,7 +28,8 @@
     white-space: normal;
     text-transform: initial;
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: @link-hover-color;
       text-decoration: underline;
     }

--- a/src/indigo/less/buttons.less
+++ b/src/indigo/less/buttons.less
@@ -4,6 +4,15 @@
   text-transform: uppercase;
   letter-spacing: 1.09091px;
 
+  &.btn-default {
+    padding-top: @padding-base * 3 - 1;
+    padding-bottom: @padding-base * 3 - 1;
+  }
+
+  &:not(.btn-default) {
+    border: none;
+  }
+
   &.btn-link {
     color: @text-color;
   }

--- a/src/indigo/less/buttons.less
+++ b/src/indigo/less/buttons.less
@@ -5,8 +5,7 @@
   letter-spacing: 1.09091px;
 
   &.btn-default {
-    padding-top: @padding-base * 3 - 1;
-    padding-bottom: @padding-base * 3 - 1;
+    padding: 11px 16px;
   }
 
   &:not(.btn-default) {

--- a/src/indigo/less/buttons.less
+++ b/src/indigo/less/buttons.less
@@ -21,7 +21,7 @@
     letter-spacing: initial;
     padding: 0;
     border: none;
-    color: @link-hover-color;
+    color: @link-color;
     display: inline;
     vertical-align: inherit;
     text-align: start;
@@ -29,6 +29,7 @@
     text-transform: initial;
 
     &:hover {
+      color: @link-hover-color;
       text-decoration: underline;
     }
   }


### PR DESCRIPTION
Fixed https://github.com/keboola/kbc-ui/issues/3862
Fixed https://github.com/keboola/kbc-ui/issues/3861

To jsem si moc nevšiml že jsem tam nechal border, nově teda tlačítka bez border, jediná vyjímka je default tlačítko, kde ale snižuji padding-top/bottom aby seděla celková velikost tlačítka.

Bez borderu se i vyřeší ten "bug" na dashboardu v boxu (výška 81px viz fixes issue).