### PR TITLE
Inline edit input

### DIFF
--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -56,7 +56,6 @@ class InlineEditTextInput extends React.Component {
             <Button
               className="inline-edit-input-submit"
               bsStyle="primary"
-              bsSize="sm"
               disabled={this.props.isSaving || !this.props.isValid}
               type="submit"
             >

--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, FormControl, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
-import { faPencilAlt } from '@fortawesome/free-solid-svg-icons/faPencilAlt';
+import { faPen } from '@fortawesome/free-solid-svg-icons/faPen';
 import Loader from './Loader';
 
 class InlineEditTextInput extends React.Component {
@@ -79,7 +79,7 @@ class InlineEditTextInput extends React.Component {
           ) : (
             <span className="text-muted">{this.props.placeholder}</span>
           )}
-          <FontAwesomeIcon icon={faPencilAlt} fixedWidth className="icon-addon-left" />
+          <FontAwesomeIcon icon={faPen} fixedWidth className="icon-addon-left" />
         </span>
       </OverlayTrigger>
     );

--- a/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
+++ b/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
@@ -78,7 +78,7 @@ exports[`<InlineEditInput /> InlineEditInput - disabled save button when text is
         </svg>
       </button>
       <button
-        className="inline-edit-input-submit btn btn-sm btn-primary"
+        className="inline-edit-input-submit btn btn-primary"
         disabled={true}
         type="submit"
       >
@@ -133,7 +133,7 @@ exports[`<InlineEditInput /> InlineEditInput - edit mode 1`] = `
         </svg>
       </button>
       <button
-        className="inline-edit-input-submit btn btn-sm btn-primary"
+        className="inline-edit-input-submit btn btn-primary"
         disabled={true}
         type="submit"
       >
@@ -222,7 +222,7 @@ exports[`<InlineEditInput /> InlineEditInput - saving in edit mode 1`] = `
         </svg>
       </button>
       <button
-        className="inline-edit-input-submit btn btn-sm btn-primary"
+        className="inline-edit-input-submit btn btn-primary"
         disabled={true}
         type="submit"
       >

--- a/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
+++ b/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
@@ -16,8 +16,8 @@ exports[`<InlineEditInput /> InlineEditInput - default 1`] = `
   </span>
   <svg
     aria-hidden="true"
-    className="svg-inline--fa fa-pencil-alt fa-w-16 fa-fw icon-addon-left"
-    data-icon="pencil-alt"
+    className="svg-inline--fa fa-pen fa-w-16 fa-fw icon-addon-left"
+    data-icon="pen"
     data-prefix="fas"
     focusable="false"
     role="img"
@@ -26,7 +26,7 @@ exports[`<InlineEditInput /> InlineEditInput - default 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+      d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
       fill="currentColor"
       style={Object {}}
     />
@@ -160,8 +160,8 @@ exports[`<InlineEditInput /> InlineEditInput - read mode 1`] = `
   </span>
   <svg
     aria-hidden="true"
-    className="svg-inline--fa fa-pencil-alt fa-w-16 fa-fw icon-addon-left"
-    data-icon="pencil-alt"
+    className="svg-inline--fa fa-pen fa-w-16 fa-fw icon-addon-left"
+    data-icon="pen"
     data-prefix="fas"
     focusable="false"
     role="img"
@@ -170,7 +170,7 @@ exports[`<InlineEditInput /> InlineEditInput - read mode 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+      d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
       fill="currentColor"
       style={Object {}}
     />

--- a/src/indigo/less/components/inline-edit-input.less
+++ b/src/indigo/less/components/inline-edit-input.less
@@ -4,7 +4,6 @@
   .inline-edit-input-form {
     display: inline;
     position: relative;
-    top: -3px;
 
     .inline-edit-input-buttons {
       position: absolute;

--- a/src/indigo/less/components/inline-edit-input.less
+++ b/src/indigo/less/components/inline-edit-input.less
@@ -1,68 +1,69 @@
 .inline-edit-input {
   display: inline;
 
-  &-form {
+  .inline-edit-input-form {
     display: inline;
     position: relative;
-  }
-
-  &-buttons {
-    position: absolute;
-    right: 4px;
     top: -3px;
 
-    .fa-spin {
+    .inline-edit-input-buttons {
       position: absolute;
-      top: 5px;
-      right: -30px;
-    }
-  }
+      right: 4px;
+      top: -3px;
 
-  &-cancel {
-    padding: 0 5px 0 5px;
-    font-size: 16px;
-    color: #e1e1e9;
+      .fa-spin {
+        position: absolute;
+        top: 5px;
+        right: -30px;
+      }
 
-    &:hover,
-    &:focus,
-    &:active {
-      text-decoration: none;
-      color: darken(#e1e1e9, 20%);
-    }
-  }
+      .inline-edit-input-cancel {
+        padding: 0 5px 0 5px;
+        font-size: 16px;
+        color: #e1e1e9;
 
-  &-submit {
-    padding: 5px 10px;
-  }
+        &:hover,
+        &:focus,
+        &:active {
+          text-decoration: none;
+          color: darken(#e1e1e9, 20%);
+        }
+      }
 
-  &-link {
-    display: inline-block;
-    padding: 11px 15px 11px;
-    border-radius: 4px;
-    cursor: pointer;
-
-    &:hover,
-    &:focus,
-    &:active {
-      background-color: #e9faff;
-
-      .fa-edit {
-        opacity: 1;
+      .inline-edit-input-submit {
+        padding: 5px 10px;
       }
     }
 
+    .inline-edit-input-control {
+      display: inline-block;
+      width: auto;
+      padding-right: 80px;
+
+      &:disabled {
+        border-color: @input-border;
+      }
+    }
+  }
+}
+
+.inline-edit-input-link {
+  display: inline-block;
+  padding: 10px 0px;
+  border-radius: @border-radius;
+  cursor: pointer;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: #e9faff;
+
     .fa-edit {
-      opacity: 0.3;
+      opacity: 1;
     }
   }
 
-  &-control {
-    display: inline-block;
-    width: auto;
-    padding: 6px 80px 6px 12px;
-
-    &:disabled {
-      border-color: @input-border;
-    }
+  .fa-edit {
+    opacity: 0.3;
   }
 }


### PR DESCRIPTION
Koukal jsem že zase nesedí CSS v kbc-ui, je to jak jsme přidal třídu pro `btn-sm`. 
Tu bylo vše stylováno flat a tak se mohlo lehce stát že někdo jiný něco přepsat (třeba ten button).

- vyhodil jsem teda to flat CSS, aby to bylo vnořené tak jak jsou ty prvky
- upravil jsem velikosti aby byl stejný input před rozklikem i po (výška 40px)
- pro `link` jsem vyhodil boční padding, myslím že to tak bude lepší, teď to bylo vždy v KBC-UI takové odsazené jak statické věci a člověk nemusel vědět proč, až když na to najel tak vidět že jde jakoby o button, u drobečkovky to taky nulujeme
- vyhodil jsem ten `bsSize` protože to beztak upravuje samy celé