### PR TITLE
PanelWithDetails - labels

### DIFF
--- a/src/indigo/components/PanelWithDetails.js
+++ b/src/indigo/components/PanelWithDetails.js
@@ -65,8 +65,8 @@ class PanelWithDetails extends React.Component {
 
 PanelWithDetails.propTypes = {
   defaultExpanded: PropTypes.bool,
-  labelCollapse: PropTypes.string,
-  labelOpen: PropTypes.string,
+  labelCollapse: PropTypes.node,
+  labelOpen: PropTypes.node,
   children: PropTypes.any.isRequired,
   placement: PropTypes.oneOf([PLACEMENT_BOTTOM, PLACEMENT_TOP]),
   preview: PropTypes.oneOf(['normal', 'small']),


### PR DESCRIPTION
`labelCollapse` a `labelOpen` může být i react element, array, nebo cokoli co umí React vyrenderovat..

Háže nám to na kbc-ui warning protože tam někdy posílámé objekt (fragment) místo stringu.