### PR TITLE
Radio, Checkbox input - remove custom styles

### DIFF
--- a/src/indigo/less/forms.less
+++ b/src/indigo/less/forms.less
@@ -24,36 +24,5 @@ label,
     height: 20px;
     margin-top: 0px;
     margin-left: -32px;
-
-    &:after {
-      content: '';
-      width: 20px;
-      height: 20px;
-      display: inline-block;
-      visibility: visible;
-      font-size: 12px;
-      text-align: center;
-      border: 1px solid @gray-light;
-      background-color: #fff;
-    }
-
-    &:checked:after {
-      content: "\2714";
-      background-color: @brand-primary;
-      color: #FFF;
-    }
-
-    &:not(:checked):hover:after {
-      content: "\2714";
-      color: @gray-light;
-    }
-  }
-
-  input[type="checkbox"]:after {
-    border-radius: @input-border-radius;
-  }
-
-  input[type="radio"]:after {
-    border-radius: 50%;
   }
 }

--- a/src/indigo/less/forms.less
+++ b/src/indigo/less/forms.less
@@ -11,18 +11,3 @@ label,
 .input-group-addon {
   background: darken(@input-bg, 5%);
 }
-
-.checkbox,
-.radio {
-  & > label {
-    padding-left: @padding-base * 8;
-  }
-
-  input[type="checkbox"],
-  input[type="radio"] {
-    width: 20px;
-    height: 20px;
-    margin-top: 0px;
-    margin-left: -32px;
-  }
-}


### PR DESCRIPTION
Fixed https://keboola.atlassian.net/browse/UI-68

Co jsem se dočetl tak Firefox a asi Edge moc nepodporuje `:after` selektor u `input[checkbox]` a `input[radio]`. Musí se to tam nějak hackovat přes další span, což asi nechcem.

Asi lepší spoléhat na default, každý prohlížeč má teda svůj.