### PR TITLE
Custom checkboxes and radio buttons

### DIFF
--- a/src/indigo/less/forms.less
+++ b/src/indigo/less/forms.less
@@ -11,3 +11,92 @@ label,
 .input-group-addon {
   background: darken(@input-bg, 5%);
 }
+
+.checkbox,
+.radio {
+  min-height: 24px;
+
+  label {
+    padding-left: 32px;
+  }
+
+  input[type="checkbox"],
+  input[type="radio"] {
+    opacity: 0;
+
+    &:not(:hover):focus + span:before {
+      outline: 5px auto -webkit-focus-ring-color;
+      outline-offset: -2px;
+    }
+
+    &:checked + span {
+      &:before {
+        background-color: @brand-primary;
+      }
+
+      &:after {
+        content: '';
+      }
+    }
+
+    & + span {
+      position: relative;
+
+      &:before {
+        content: "";
+        display: inline-block;
+        height: 24px;
+        width: 24px;
+        border: 1px solid @gray-light;
+        border-radius: 4px;
+        position: absolute;
+        left: -32px;
+        top: -4px;
+      }
+
+      &:after {
+        content: none;
+        display: inline-block;
+        height: 7px;
+        width: 14px;
+        border-left: 2px solid #fff;
+        border-bottom: 2px solid #fff;
+        transform: rotate(-45deg);
+        position: absolute;
+        left: -27px;
+        top: 3px;
+      }
+    }
+  }
+
+  input[type="radio"] + span:before {
+    border-radius: 50%;
+  }
+
+  &.compact {
+    min-height: 20px;
+
+    input[type="checkbox"],
+    input[type="radio"] {
+
+      & + span {
+        position: relative;
+
+        &:before {
+          content: "";
+          height: 16px;
+          width: 16px;
+          left: -28px;
+          top: 0px;
+        }
+
+        &:after {
+          height: 5px;
+          width: 10px;
+          left: -25px;
+          top: 5px;
+        }
+      }
+    }
+  }
+}

--- a/src/stories/Bootstrap/index.js
+++ b/src/stories/Bootstrap/index.js
@@ -285,11 +285,30 @@ storiesOf('Bootstrap', module)
       <div className="bs-docs-section">
         <div className="bs-example">
           <form>
-            <Checkbox>Checkbox</Checkbox>
+            <Checkbox>
+              <span>Checkbox</span>
+            </Checkbox>
+
+            <Checkbox className="compact">
+              <span>Smaller Checkbox</span>
+            </Checkbox>
 
             <FormGroup>
-              <Radio name="radioGroup">1</Radio> <Radio name="radioGroup">2</Radio>{' '}
-              <Radio name="radioGroup">3</Radio>
+              <Radio name="radioGroup">
+                <span>1</span>
+              </Radio>
+              <Radio name="radioGroup">
+                <span>2</span>
+              </Radio>
+            </FormGroup>
+
+            <FormGroup>
+              <Radio name="radioGroup2" className="compact">
+                <span>3</span>
+              </Radio>
+              <Radio name="radioGroup2" className="compact">
+                <span>4</span>
+              </Radio>
             </FormGroup>
 
             <FormGroup controlId="formControlsSelect">


### PR DESCRIPTION
Tak nová "lepší" verze.

Lepší je v tom že funguje stejně jak v Chrome tak již i ve Firefoxu, Edge a doufám i Safari atd.
Horší v tom že je potřeba upravit pak v KBC všude markup, bez toho je to asi neřešitelné.

Změna spočívá v úpravě typu:
```jsx
<Checkbox>Popisek</Checkbox>
```
na
```jsx
<Checkbox><span>Popisek</span><Checkbox>
```
to samé platí pro `<Radio />`

Jinak jsem se snažil zachovat i accessibilitu když jdu třeba přes tab apod. Samo nativní chování bude vždy o něco lepší.

Plus ještě lze přidat třídu `compact` kde je pak checkbox, radio menší. Je to použito třeba při bucket sharingu a ještě někde, že tam jsou menší checkboxy.