### PR TITLE
Button styles - Do not use margin-bottom

### DIFF
--- a/src/indigo/less/buttons.less
+++ b/src/indigo/less/buttons.less
@@ -3,16 +3,22 @@
   line-height: 18px;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 1.09091px;
+  letter-spacing: @letter-spacing-wider;
   padding: 12px 16px 10px 16px;
   border-radius: @border-radius;
 
   .svg-inline--fa {
     font-size: 16px;
     vertical-align: middle;
-    margin-bottom: 2px;
+    position: relative;
+    bottom: 1px;
+
     &.icon-addon-right {
       margin-right: 12px;
+    }
+
+    &.icon-addon-left {
+      margin-left: 12px;
     }
   }
 
@@ -22,7 +28,6 @@
 
     .svg-inline--fa {
       font-size: 16px;
-      vertical-align: middle;
     }
   }
 


### PR DESCRIPTION
Toto je ještě něco jiného.

Koukal jsme že SM tlačítka s ikonkou mají velikost cca 32.12px.
Dělal to tam ten margin tak jsem místo toho hodil relative pozici.
Vyhodil jsme jeden duplicitní styl a jednou použil variable.
Plus pro konzistenci jsme nahodil i upravenou velikost marginu pro `icon-addon-left`.