### PR TITLE
Update react bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "^2.2.1",
     "prop-types": "^15.7.2",
     "react": "~16.8.6",
-    "react-bootstrap": "^0.31.5",
+    "react-bootstrap": "^0.33.1",
     "react-dom": "~16.8.6",
     "react-scripts": "^4.0.1",
     "react-test-renderer": "~16.8.6",
@@ -59,7 +59,7 @@
     "moment": "^2.22.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
-    "react-bootstrap": "^0.31.5",
+    "react-bootstrap": "^0.33.1",
     "react-dom": "^16.8.6"
   },
   "devEngines": {

--- a/src/indigo/components/PanelWithDetails.js
+++ b/src/indigo/components/PanelWithDetails.js
@@ -25,26 +25,21 @@ class PanelWithDetails extends React.Component {
   render() {
     return (
       <Panel
-        collapsible
+        onToggle={this.toggleExpanded}
         expanded={this.state.expanded}
-        onSelect={this.toggleExpanded}
-        header={this.renderHeader()}
         className={classnames('panel-show-details', `panel-show-details-${this.props.placement}`, {
           'panel-preview': !!this.props.preview,
           [`panel-preview-${this.props.preview}`]: !!this.props.preview,
         })}
       >
-        {this.props.children}
+        <Panel.Heading>
+          <Panel.Title toggle>
+            <FontAwesomeIcon fixedWidth icon={this.getIcon()} className="icon-addon-right" />
+            {this.state.panelHeaderTitle}
+          </Panel.Title>
+        </Panel.Heading>
+        <Panel.Body collapsible>{this.props.children}</Panel.Body>
       </Panel>
-    );
-  }
-
-  renderHeader() {
-    return (
-      <div>
-        <FontAwesomeIcon fixedWidth icon={this.getIcon()} className="icon-addon-right" />
-        {this.state.panelHeaderTitle}
-      </div>
     );
   }
 

--- a/src/indigo/components/__snapshots__/PanelWithDetails.test.js.snap
+++ b/src/indigo/components/__snapshots__/PanelWithDetails.test.js.snap
@@ -3,7 +3,6 @@
 exports[`<PanelWithDetails /> PanelWithDetails - bottom controls 1`] = `
 <div
   className="panel-show-details panel-show-details-bottom panel panel-default"
-  id={null}
 >
   <div
     className="panel-heading"
@@ -13,9 +12,11 @@ exports[`<PanelWithDetails /> PanelWithDetails - bottom controls 1`] = `
     >
       <a
         aria-expanded={false}
-        aria-selected={false}
         className="collapsed"
+        href="#"
         onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
       >
         <svg
           aria-hidden="true"
@@ -40,7 +41,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - bottom controls 1`] = `
   </div>
   <div
     aria-expanded={null}
-    aria-hidden={true}
     className="panel-collapse collapse"
   >
     <div
@@ -55,7 +55,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - bottom controls 1`] = `
 exports[`<PanelWithDetails /> PanelWithDetails - custom labels 1`] = `
 <div
   className="panel-show-details panel-show-details-top panel panel-default"
-  id={null}
 >
   <div
     className="panel-heading"
@@ -65,9 +64,11 @@ exports[`<PanelWithDetails /> PanelWithDetails - custom labels 1`] = `
     >
       <a
         aria-expanded={false}
-        aria-selected={false}
         className="collapsed"
+        href="#"
         onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
       >
         <svg
           aria-hidden="true"
@@ -92,7 +93,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - custom labels 1`] = `
   </div>
   <div
     aria-expanded={null}
-    aria-hidden={true}
     className="panel-collapse collapse"
   >
     <div
@@ -107,7 +107,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - custom labels 1`] = `
 exports[`<PanelWithDetails /> PanelWithDetails - default 1`] = `
 <div
   className="panel-show-details panel-show-details-top panel panel-default"
-  id={null}
 >
   <div
     className="panel-heading"
@@ -117,9 +116,11 @@ exports[`<PanelWithDetails /> PanelWithDetails - default 1`] = `
     >
       <a
         aria-expanded={false}
-        aria-selected={false}
         className="collapsed"
+        href="#"
         onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
       >
         <svg
           aria-hidden="true"
@@ -144,7 +145,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - default 1`] = `
   </div>
   <div
     aria-expanded={null}
-    aria-hidden={true}
     className="panel-collapse collapse"
   >
     <div
@@ -159,7 +159,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - default 1`] = `
 exports[`<PanelWithDetails /> PanelWithDetails - default expanded 1`] = `
 <div
   className="panel-show-details panel-show-details-top panel panel-default"
-  id={null}
 >
   <div
     className="panel-heading"
@@ -169,9 +168,11 @@ exports[`<PanelWithDetails /> PanelWithDetails - default expanded 1`] = `
     >
       <a
         aria-expanded={true}
-        aria-selected={true}
-        className={null}
+        className=""
+        href="#"
         onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
       >
         <svg
           aria-hidden="true"
@@ -196,7 +197,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - default expanded 1`] = `
   </div>
   <div
     aria-expanded={null}
-    aria-hidden={false}
     className="panel-collapse collapse in"
   >
     <div
@@ -211,7 +211,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - default expanded 1`] = `
 exports[`<PanelWithDetails /> PanelWithDetails - small preview 1`] = `
 <div
   className="panel-show-details panel-show-details-top panel-preview panel-preview-small panel panel-default"
-  id={null}
 >
   <div
     className="panel-heading"
@@ -221,9 +220,11 @@ exports[`<PanelWithDetails /> PanelWithDetails - small preview 1`] = `
     >
       <a
         aria-expanded={false}
-        aria-selected={false}
         className="collapsed"
+        href="#"
         onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
       >
         <svg
           aria-hidden="true"
@@ -248,7 +249,6 @@ exports[`<PanelWithDetails /> PanelWithDetails - small preview 1`] = `
   </div>
   <div
     aria-expanded={null}
-    aria-hidden={true}
     className="panel-collapse collapse"
   >
     <div

--- a/src/stories/Bootstrap/index.js
+++ b/src/stories/Bootstrap/index.js
@@ -19,6 +19,7 @@ import {
   Tabs,
   DropdownButton,
   MenuItem,
+  PanelGroup,
   ProgressBar,
   ListGroup,
   ListGroupItem,
@@ -30,7 +31,6 @@ import {
   ButtonToolbar,
   Modal,
   InputGroup,
-  Accordion,
   Panel,
   FormControl,
   Label,
@@ -231,43 +231,56 @@ storiesOf('Bootstrap', module)
   ))
   .add('Panel', () => (
     <div>
-      <Panel header="Panel heading without title">Panel content</Panel>
-      <Panel header="Panel title">Panel content</Panel>
+      <Panel>
+        <Panel.Heading>Panel heading without title</Panel.Heading>
+        <Panel.Body>Panel content</Panel.Body>
+      </Panel>
+      <Panel>
+        <Panel.Heading>
+          <Panel.Title>Panel heading with title</Panel.Title>
+        </Panel.Heading>
+        <Panel.Body>Panel content</Panel.Body>
+      </Panel>
     </div>
   ))
-  .add('Well', () => <Well>WELL, Well, well ...</Well>)
   .add(
-    'Accordion',
+    'PanelGroup',
     () => (
-      <Accordion>
-        <Panel header="Collapsible Group Item #1" eventKey="1">
-          Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
-          squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa
-          nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid
-          single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft
-          beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher
-          vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt
-          you probably haven't heard of them accusamus labore sustainable VHS.
+      <PanelGroup accordion id="accordion-example">
+        <Panel eventKey="1">
+          <Panel.Heading>
+            <Panel.Title toggle>Collapsible Group Item #1</Panel.Title>
+          </Panel.Heading>
+          <Panel.Body collapsible>
+            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
+            squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck
+            quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it
+            squid single-origin coffee nulla assumenda shoreditch et.
+          </Panel.Body>
         </Panel>
-        <Panel header="Collapsible Group Item #2" eventKey="2">
-          Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
-          squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa
-          nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid
-          single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft
-          beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher
-          vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt
-          you probably haven't heard of them accusamus labore sustainable VHS.
+        <Panel eventKey="2">
+          <Panel.Heading>
+            <Panel.Title toggle>Collapsible Group Item #2</Panel.Title>
+          </Panel.Heading>
+          <Panel.Body collapsible>
+            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
+            squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck
+            quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it
+            squid single-origin coffee nulla assumenda shoreditch et.
+          </Panel.Body>
         </Panel>
-        <Panel header="Collapsible Group Item #3" eventKey="3">
-          Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
-          squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa
-          nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid
-          single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft
-          beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher
-          vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt
-          you probably haven't heard of them accusamus labore sustainable VHS.
+        <Panel eventKey="3">
+          <Panel.Heading>
+            <Panel.Title toggle>Collapsible Group Item #3</Panel.Title>
+          </Panel.Heading>
+          <Panel.Body collapsible>
+            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
+            squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck
+            quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it
+            squid single-origin coffee nulla assumenda shoreditch et.
+          </Panel.Body>
         </Panel>
-      </Accordion>
+      </PanelGroup>
     ),
     {
       info: {
@@ -521,6 +534,7 @@ storiesOf('Bootstrap', module)
       <code>Sample text here.. &lt;section&gt; Sample text here..</code>
     </div>
   ))
+  .add('Well', () => <Well>WELL, Well, well ...</Well>)
   .add('Badge', () => <Badge>42</Badge>)
   .add('Label', () => (
     <div>

--- a/src/stories/ModalConfiguration/index.js
+++ b/src/stories/ModalConfiguration/index.js
@@ -17,21 +17,19 @@ import {
 storiesOf('[CSS] ModalConfiguration', module).add('Modal Configuration', () => {
   return (
     <div className="static-modal" style={{ position: 'relative' }}>
-      <Modal.Dialog className="modal-configuration">
-        <Modal.Header className="modal-configuration-header" closeButton>
+      <Modal.Dialog>
+        <Modal.Header closeButton>
           <Row>
             <Col xs={3}>
-              <span className="kb-sapi-component-icon modal-configuration-icon">
-                <img
-                  src="https://avatars2.githubusercontent.com/u/1424387?s=200&amp;v=4"
-                  width="64"
-                  height="64"
-                  alt="component logo"
-                />
-              </span>
-            </Col>
+              <img
+                src="https://avatars2.githubusercontent.com/u/1424387?s=200&amp;v=4"
+                width="64"
+                height="64"
+                alt="component logo"
+              />
+          </Col>
             <Col xs={9}>
-              <Modal.Title componentClass="h2" className="modal-configuration-title">
+              <Modal.Title componentClass="h2">
                 Keboola
               </Modal.Title>
               <p>
@@ -41,7 +39,7 @@ storiesOf('[CSS] ModalConfiguration', module).add('Modal Configuration', () => {
             </Col>
           </Row>
         </Modal.Header>
-        <Modal.Body className="modal-configuration-body">
+        <Modal.Body>
           <Form horizontal>
             <FormGroup>
               <Col componentClass={ControlLabel} xs={3}>

--- a/src/styles/indigo-storybook.less
+++ b/src/styles/indigo-storybook.less
@@ -8,6 +8,8 @@ body {
 }
 
 #root > div > #story-root {
+  position: relative;
+  min-height: 100px;
   padding: 16px;
   border: 1px solid rgb(220, 220, 220);
   border-top: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,6 +2087,14 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-transform-typescript" "^7.12.1"
 
+"@babel/runtime-corejs2@^7.0.0":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz#382ec38f0826365e96118e28b81249c1c61bace3"
+  integrity sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.10.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
@@ -3639,6 +3647,14 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/react@^16.9.11":
+  version "16.14.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.2.tgz#85dcc0947d0645349923c04ccef6018a1ab7538c"
+  integrity sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
@@ -5172,7 +5188,7 @@ babel-preset-react-app@^10.0.0:
     babel-plugin-macros "2.8.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
 
-babel-runtime@^6.11.6, babel-runtime@^6.26.0:
+babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -6312,6 +6328,11 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
+core-js@^2.6.5:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
 core-js@^3.0.1, core-js@^3.0.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
@@ -6695,6 +6716,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
+
+csstype@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
+  integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -9629,7 +9655,7 @@ interpret@~1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
-invariant@^2.1.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -10894,7 +10920,7 @@ jsx-ast-utils@^3.1.0:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
-keycode@^2.1.2:
+keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
   integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
@@ -14070,20 +14096,22 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
-react-bootstrap@^0.31.5:
-  version "0.31.5"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.31.5.tgz#57040fa8b1274e1e074803c21a1b895fdabea05a"
-  integrity sha512-xgDihgX4QvYHmHzL87faDBMDnGfYyqcrqV0TEbWY+JizePOG1vfb8M3xJN+6MJ3kUYqDtQSZ7v/Q6Y5YDrkMdA==
+react-bootstrap@^0.33.1:
+  version "0.33.1"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.33.1.tgz#e072592aa143b9792526281272eca754bc9a4940"
+  integrity sha512-qWTRravSds87P8WC82tETy2yIso8qDqlIm0czsrduCaYAFtHuyLu0XDbUlfLXeRzqgwm5sRk2wRaTNoiVkk/YQ==
   dependencies:
-    babel-runtime "^6.11.6"
+    "@babel/runtime-corejs2" "^7.0.0"
     classnames "^2.2.5"
     dom-helpers "^3.2.0"
-    invariant "^2.2.1"
-    keycode "^2.1.2"
-    prop-types "^15.5.10"
+    invariant "^2.2.4"
+    keycode "^2.2.0"
+    prop-types "^15.6.1"
     prop-types-extra "^1.0.1"
-    react-overlays "^0.7.4"
-    uncontrollable "^4.1.0"
+    react-overlays "^0.9.0"
+    react-prop-types "^0.4.0"
+    react-transition-group "^2.0.0"
+    uncontrollable "^7.0.2"
     warning "^3.0.0"
 
 react-clientside-effect@^1.2.2:
@@ -14292,7 +14320,12 @@ react-inspector@^4.0.0:
     prop-types "^15.6.1"
     storybook-chromatic "^2.2.2"
 
-react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.6:
+react-is@^16.3.2:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.6:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -14307,15 +14340,16 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-overlays@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.4.tgz#ef2ec652c3444ab8aa014262b18f662068e56d5c"
-  integrity sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==
+react-overlays@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.9.3.tgz#5bac8c1e9e7e057a125181dee2d784864dd62902"
+  integrity sha512-u2T7nOLnK+Hrntho4p0Nxh+BsJl0bl4Xuwj/Y0a56xywLMetgAfyjnDVrudLXsNcKGaspoC+t3C1V80W9QQTdQ==
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"
     prop-types "^15.5.10"
     prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.1"
     warning "^3.0.0"
 
 react-popper-tooltip@^2.8.3:
@@ -14338,6 +14372,13 @@ react-popper@^1.3.6:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-prop-types@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-prop-types/-/react-prop-types-0.4.0.tgz#f99b0bfb4006929c9af2051e7c1414a5c75b93d0"
+  integrity sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=
+  dependencies:
+    warning "^3.0.0"
 
 react-refresh@^0.8.3:
   version "0.8.3"
@@ -14463,7 +14504,7 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^2.2.1:
+react-transition-group@^2.0.0, react-transition-group@^2.2.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
@@ -16848,12 +16889,15 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-uncontrollable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
-  integrity sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=
+uncontrollable@^7.0.2:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.1.1.tgz#f67fed3ef93637126571809746323a9db815d556"
+  integrity sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==
   dependencies:
-    invariant "^2.1.0"
+    "@babel/runtime" "^7.6.3"
+    "@types/react" "^16.9.11"
+    invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
 
 underscore.string@~3.3.5:
   version "3.3.5"


### PR DESCRIPTION
Navazuje na https://github.com/keboola/indigo-ui/pull/452

- update react-bootstrap na 0.33.1
- šlo jen o update `<Panel />` komponent, který změnily docela API, šlo o Panel stories z bootstrapu + naší komponentu `<PanelWidthDetails />`

Pokud by to bylo vše ok asi bych to vydal jako verzi 13 pro jistotu. Když bude potřeba upravit i KBC-UI před použitím.