### PR TITLE
Move immutable to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "bootstrap": "^3.4.1",
     "classnames": "^2.2.6",
     "core-js": "^3.2.1",
-    "immutable": "^3.7.3",
     "prop-types": "^15.7.2",
     "react-input-autosize": "^2.2.2"
   },
@@ -39,6 +38,7 @@
     "grunt-contrib-less": "^2.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-stylelint": "^0.11.1",
+    "immutable": "^3.7.3",
     "mockdate": "^2.0.5",
     "moment": "^2.24.0",
     "npm-run-all": "^4.1.5",
@@ -54,6 +54,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.21",
     "@fortawesome/free-solid-svg-icons": "^5.10.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
+    "immutable": "^3.7.3",
     "moment": "^2.22.2",
     "react": "^16.8.6",
     "react-bootstrap": "^0.31.5",

--- a/src/indigo/components/tree/TreeNode.js
+++ b/src/indigo/components/tree/TreeNode.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Immutable from 'immutable';
+import { Iterable } from 'immutable';
 
 import Protected from '../Protected';
 
@@ -14,9 +14,7 @@ class TreeNode extends React.Component {
   renderRow(value, key) {
     return (
       <li key={key}>
-        {Immutable.Iterable.isIterable(value)
-          ? this.renderNode(value, key)
-          : this.renderLeaf(value, key)}
+        {Iterable.isIterable(value) ? this.renderNode(value, key) : this.renderLeaf(value, key)}
       </li>
     );
   }


### PR DESCRIPTION
Jira issue: https://keboola.atlassian.net/browse/UI-728

Changes:

- Import Iterable with destructing
- Move immutable to peerDependencies

---

Toto zabezpeci, ze projekty, ktore pouzivaju indigo-ui a zaroven immutablejs, budu mat immutable len 1x.