### PR TITLE
Use Node 14 for local development and build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 jobs:
   include:
     - stage: test
+      name: "Run stylelint; Run tests; Build storybook"
       script:
         - set -e
         - yarn stylelint
@@ -18,6 +19,7 @@ jobs:
         - yarn build-dev-css
         - yarn build-storybook
     - stage: test
+      name: "Build lib"
       script: yarn build-lib
 
     - stage: deploy storybook

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 services:
   - docker
 
-node_js: "12"
+node_js: "14"
 
 install:
   - yarn

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Indigo UI library, its CSS and React components. Also Styleguide app showing usa
 
 ## Development
 
-1. Make sure you have Node 12 installed `node -v`
+1. Make sure you have Node 14 installed `node -v`
 2. Install grunt: `yarn global add grunt-cli`
 3. Install dependencies: `yarn`
 4. Run storybook `yarn storybook`


### PR DESCRIPTION
Jira issue: https://keboola.atlassian.net/browse/UI-1613

Changes:

- Use Node 14 for local development and build
 
---

Opat len Node na 14ku.
