### PR TITLE
Indigo - inline edit input - placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "description": "Keboola UI library",
   "version": "13.0.0",
   "dependencies": {
-    "bootstrap": "^3.4.1",
-    "react-input-autosize": "^3.0.0"
+    "bootstrap": "^3.4.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",
@@ -46,6 +45,7 @@
     "react": "^16.14.0",
     "react-bootstrap": "^0.33.1",
     "react-dom": "^16.14.0",
+    "react-input-autosize": "^3.0.0",
     "react-scripts": "^4.0.3",
     "react-test-renderer": "^16.14.0",
     "stylelint": "^13.8.0"
@@ -60,7 +60,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
     "react-bootstrap": "^0.33.1",
-    "react-dom": "^16.14.0"
+    "react-dom": "^16.14.0",
+    "react-input-autosize": "^3.0.0"
   },
   "devEngines": {
     "node": "8.x",

--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -12,8 +12,6 @@ class InlineEditTextInput extends React.Component {
   constructor(props) {
     super(props);
 
-    this.controlRef = null;
-
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
@@ -27,12 +25,6 @@ class InlineEditTextInput extends React.Component {
     return this.renderStaticInput();
   }
 
-  componentDidUpdate(prevProps) {
-    if (!prevProps.isEditing && this.props.isEditing) {
-      this.controlRef.focus();
-    }
-  }
-
   renderEditInput() {
     return (
       <Form inline className="inline-edit-input" onSubmit={this.handleSubmit}>
@@ -42,9 +34,7 @@ class InlineEditTextInput extends React.Component {
           placeholder={this.props.placeholder}
           onChange={this.handleChange}
           onKeyDown={this.handleKeyDown}
-          inputRef={(ref) => {
-            this.controlRef = ref;
-          }}
+          inputRef={(ref) => ref?.focus()}
         />
         <Button
           type="submit"

--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -16,6 +16,7 @@ class InlineEditTextInput extends React.Component {
 
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   render() {
@@ -39,6 +40,7 @@ class InlineEditTextInput extends React.Component {
           inputClassName="form-control inline-edit-input-control"
           value={this.props.text}
           onChange={this.handleChange}
+          onKeyDown={this.handleKeyDown}
           inputRef={(ref) => {
             this.controlRef = ref;
           }}
@@ -75,6 +77,12 @@ class InlineEditTextInput extends React.Component {
 
   renderTooltip() {
     return <Tooltip id="inline-edit-input-tooltip">{this.props.editTooltip}</Tooltip>;
+  }
+
+  handleKeyDown(e) {
+    if (['Esc', 'Escape'].includes(e.key)) {
+      this.props.onEditCancel();
+    }
   }
 
   handleChange(e) {

--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -60,7 +60,9 @@ class InlineEditTextInput extends React.Component {
           ) : (
             <span className="text-muted">{this.props.placeholder}</span>
           )}
-          <FontAwesomeIcon icon={faPen} fixedWidth className="icon-addon-left" />
+          {this.props.showEditIcon && (
+            <FontAwesomeIcon icon={faPen} fixedWidth className="icon-addon-left" />
+          )}
         </span>
       </OverlayTrigger>
     );
@@ -98,6 +100,7 @@ InlineEditTextInput.propTypes = {
   editTooltip: PropTypes.string,
   tooltipPlacement: PropTypes.string,
   placeholder: PropTypes.string,
+  showEditIcon: PropTypes.bool,
 };
 
 InlineEditTextInput.defaultProps = {
@@ -106,6 +109,7 @@ InlineEditTextInput.defaultProps = {
   tooltipPlacement: 'top',
   isSaving: false,
   isEditing: false,
+  showEditIcon: true,
 };
 
 export default InlineEditTextInput;

--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -39,6 +39,7 @@ class InlineEditTextInput extends React.Component {
         <AutosizeInput
           inputClassName="form-control inline-edit-input-control"
           value={this.props.text}
+          placeholder={this.props.placeholder}
           onChange={this.handleChange}
           onKeyDown={this.handleKeyDown}
           inputRef={(ref) => {

--- a/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
+++ b/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
@@ -49,6 +49,8 @@ exports[`<InlineEditInput /> InlineEditInput - disabled save button when text is
     <input
       className="form-control inline-edit-input-control"
       onChange={[Function]}
+      onKeyDown={[Function]}
+      placeholder="Click to edit"
       style={
         Object {
           "boxSizing": "content-box",
@@ -70,6 +72,21 @@ exports[`<InlineEditInput /> InlineEditInput - disabled save button when text is
       }
     >
       
+    </div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "left": 0,
+          "overflow": "scroll",
+          "position": "absolute",
+          "top": 0,
+          "visibility": "hidden",
+          "whiteSpace": "pre",
+        }
+      }
+    >
+      Click to edit
     </div>
   </div>
   <button
@@ -138,6 +155,8 @@ exports[`<InlineEditInput /> InlineEditInput - edit mode 1`] = `
     <input
       className="form-control inline-edit-input-control"
       onChange={[Function]}
+      onKeyDown={[Function]}
+      placeholder="Click to edit"
       style={
         Object {
           "boxSizing": "content-box",
@@ -159,6 +178,21 @@ exports[`<InlineEditInput /> InlineEditInput - edit mode 1`] = `
       }
     >
       
+    </div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "left": 0,
+          "overflow": "scroll",
+          "position": "absolute",
+          "top": 0,
+          "visibility": "hidden",
+          "whiteSpace": "pre",
+        }
+      }
+    >
+      Click to edit
     </div>
   </div>
   <button
@@ -261,6 +295,8 @@ exports[`<InlineEditInput /> InlineEditInput - saving in edit mode 1`] = `
     <input
       className="form-control inline-edit-input-control"
       onChange={[Function]}
+      onKeyDown={[Function]}
+      placeholder="Click to edit"
       style={
         Object {
           "boxSizing": "content-box",
@@ -282,6 +318,21 @@ exports[`<InlineEditInput /> InlineEditInput - saving in edit mode 1`] = `
       }
     >
       
+    </div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "left": 0,
+          "overflow": "scroll",
+          "position": "absolute",
+          "top": 0,
+          "visibility": "hidden",
+          "whiteSpace": "pre",
+        }
+      }
+    >
+      Click to edit
     </div>
   </div>
   <button

--- a/src/stories/InlineEditInput/examples/InlineEditInput.js
+++ b/src/stories/InlineEditInput/examples/InlineEditInput.js
@@ -53,7 +53,7 @@ export default class InlineEditInputExample extends React.Component {
           text={this.state.text}
           isSaving={this.state.isSaving}
           editTooltip="Click to edit"
-          placeholder="Click to edit"
+          placeholder={this.state.isEditing ? 'Writer name' : 'Click to edit'}
         />
       </h1>
     );


### PR DESCRIPTION
Navazuje na https://github.com/keboola/indigo-ui/pull/462
Jira issue: https://keboola.atlassian.net/browse/UI-1746

Changes:
- "esc" ukončí editaci (v kbc-ui už to máme pro inline editaci code name v nových transformací a u inline edit area která je třeba u description, toto je poslední místo kde se to doplní ať je to jednotné)
- placeholder se doplní i do inputu když edituji (je na userovi ať tu hlášku připadně upraví pro edit, má nad tím plnou kontrolu)
- trošku jsme zjednodušil focus, tam to není potřeba ukládat do komponenty
- přidaná props na skrytí edit ikonky

Jinak tu už používám `e.key` teda místo `keyCode` co máme v kbc-ui. Ten `keyCode` je deprecated tak aspoň tu už takto líp. Koukám zde a jsou tam dvě možnosti https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#example (Esc a Escape) ale možná by nám stačit i ten Escape, ale zase asi pro jistotu je to supr drobnost).