### PR TITLE
Tune inline edit text input

### DIFF
--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -110,6 +110,7 @@ InlineEditTextInput.defaultProps = {
   isSaving: false,
   isEditing: false,
   showEditIcon: true,
+  isValid: true,
 };
 
 export default InlineEditTextInput;

--- a/src/indigo/components/InlineEditInput.js
+++ b/src/indigo/components/InlineEditInput.js
@@ -44,7 +44,14 @@ class InlineEditTextInput extends React.Component {
         >
           {this.props.isSaving ? <Loader /> : <FontAwesomeIcon icon={faCheck} />}
         </Button>
-        <Button type="reset" disabled={this.props.isSaving} onClick={this.props.onEditCancel}>
+        <Button
+          type="reset"
+          disabled={this.props.isSaving}
+          onClick={(event) => {
+            event.preventDefault();
+            this.props.onEditCancel();
+          }}
+        >
           <FontAwesomeIcon icon={faTimes} />
         </Button>
       </Form>
@@ -54,7 +61,13 @@ class InlineEditTextInput extends React.Component {
   renderStaticInput() {
     return (
       <OverlayTrigger placement={this.props.tooltipPlacement} overlay={this.renderTooltip()}>
-        <span className="inline-edit-input-edit" onClick={this.props.onEditStart}>
+        <span
+          className="inline-edit-input-edit"
+          onClick={(event) => {
+            event.preventDefault();
+            this.props.onEditStart();
+          }}
+        >
           {this.props.text ? (
             this.props.text
           ) : (

--- a/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
+++ b/src/indigo/components/__snapshots__/InlineEditInput.test.js.snap
@@ -197,7 +197,7 @@ exports[`<InlineEditInput /> InlineEditInput - edit mode 1`] = `
   </div>
   <button
     className="btn btn-primary"
-    disabled={true}
+    disabled={false}
     onClick={[Function]}
     type="submit"
   >


### PR DESCRIPTION
Changes:

- Add default `true` value to `isValid` prop
- Remove events and prevent default in `onEditStart` and `onEditCancel` handlers

---

ref.: https://github.com/keboola/kbc-ui/pull/6364#discussion_r713616061
