### PR TITLE
Allow add custom class to submit button in ConfirmButtons component

### DIFF
--- a/src/indigo/components/ConfirmButtons.js
+++ b/src/indigo/components/ConfirmButtons.js
@@ -30,7 +30,7 @@ class ConfirmButtons extends React.Component {
 
     return (
       <Button
-        className="btn-confirm"
+        className={classnames('btn-confirm', this.props.saveButtonClass)}
         block={this.props.block}
         type={this.props.saveButtonType}
         bsStyle={this.props.saveStyle}
@@ -98,6 +98,7 @@ ConfirmButtons.propTypes = {
   showSave: PropTypes.bool,
   block: PropTypes.bool,
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  saveButtonClass: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   children: PropTypes.any,
 };
 


### PR DESCRIPTION
Jira issue: https://keboola.atlassian.net/browse/UI-3034

Changes:
- přidaná možnost nastavit submit buttonu custom třídy, využití v UI je právě teď pro ty externí třídy, abych je mohl přidat k submitu

Už máme props `saveLabel`, `saveStyle` tak ve stejném stylu přidáno `saveButtonClass`. Nebo nevím zda lepší název třeba jen `saveClass`.